### PR TITLE
separate names for the various parameter typeclasses

### DIFF
--- a/bedrock2/src/BasicALU.v
+++ b/bedrock2/src/BasicALU.v
@@ -1,6 +1,6 @@
 Require Import bedrock2.Macros bedrock2.Syntax.
 
-Class operations {p: unique! Syntax.parameters} :=
+Class operations {p: unique! Syntax_parameters} :=
   {
     bop_add : bopname;
     bop_sub : bopname;

--- a/bedrock2/src/BasicC64Semantics.v
+++ b/bedrock2/src/BasicC64Semantics.v
@@ -1,10 +1,10 @@
-Require Import bedrock2.BasicC64Syntax bedrock2.Semantics.
+Require Import bedrock2.BasicC64Syntax bedrock2.Semantics bedrock2.StringNames.
 Require bedrock2.String bedrock2.Map.UnorderedList.
 Require bbv.Word.
 
 Local Definition shiftWidth s := Word.wordToNat (Word.wand s (Word.NToWord 64 63)).
-Instance parameters : parameters := {|
-  syntax := StringNames.Syntax.make BasicC64Syntax.parameters;
+Instance parameters : Semantics_parameters := {|
+  syntax := StringNames_to_Syntax_parameters BasicC64Syntax.parameters;
   word := Word.word 64;
   word_zero := Word.wzero 64;
   word_succ := Word.wplus (Word.wone 64);

--- a/bedrock2/src/BasicC64Syntax.v
+++ b/bedrock2/src/BasicC64Syntax.v
@@ -7,16 +7,17 @@ Module Import bopname.
   Inductive bopname := add | sub | and | or | xor | sru | slu | srs | lts | ltu | eq.
 End bopname.
 
-Definition parameters : bedrock2.StringNames.Syntax.parameters := {|
-  StringNames.Syntax.bopname := bopname;
-  StringNames.Syntax.actname := string
+Definition parameters : StringNames_parameters := {|
+  StringNames.bopname := bopname;
+  StringNames.actname := string
 |}.
 
 Definition BasicALU : BasicALU.operations :=
-  Build_operations (StringNames.Syntax.make parameters) add sub and or xor sru slu srs lts ltu eq.
+  Build_operations (StringNames_to_Syntax_parameters parameters)
+                   add sub and or xor sru slu srs lts ltu eq.
 
-Definition to_c_parameters : ToCString.parameters := {|
-  syntax := (StringNames.Syntax.make parameters);
+Definition to_c_parameters : ToCString_parameters := {|
+  syntax := StringNames_to_Syntax_parameters parameters;
   c_lit w := DecimalString.NilZero.string_of_int (BinInt.Z.to_int w) ++ "ULL";
   c_bop := fun e1 op e2 =>
              match op with

--- a/bedrock2/src/Examples/BinarySearch.v
+++ b/bedrock2/src/Examples/BinarySearch.v
@@ -5,7 +5,7 @@ Import BinInt String.
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.
 
 Section bsearch.
-  Context {p : unique! StringNames.Syntax.parameters} {b : BasicALU.operations}.
+  Context {p : unique! StringNames_parameters} {b : BasicALU.operations}.
   Local Coercion literal (z : Z) : expr := expr.literal z.
   Local Coercion var (x : String.string) : expr := expr.var x.
 

--- a/bedrock2/src/Examples/MultipleReturnValues.v
+++ b/bedrock2/src/Examples/MultipleReturnValues.v
@@ -5,7 +5,7 @@ Import BinInt String.
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.
 
 Section MultipleReturnValues.
-  Context {p : unique! StringNames.Syntax.parameters} {ALU : BasicALU.operations}.
+  Context {p : unique! StringNames_parameters} {ALU : BasicALU.operations}.
   Local Coercion literal (z : Z) : expr := expr.literal z.
   Local Coercion var (x : String.string) : expr := expr.var x.
 

--- a/bedrock2/src/Examples/StructAccess.v
+++ b/bedrock2/src/Examples/StructAccess.v
@@ -3,7 +3,7 @@ Require Import bedrock2.Syntax bedrock2.Structs bedrock2.NotationsInConstr.
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.
 
 Section StructAccess.
-  Context {p : Syntax.parameters} {bp : BasicALU.operations}.
+  Context {p : Syntax_parameters} {bp : BasicALU.operations}.
 
   Definition item : type := inr (Struct (
     ("a", inl 1)::

--- a/bedrock2/src/Examples/Swap.v
+++ b/bedrock2/src/Examples/Swap.v
@@ -5,7 +5,7 @@ Import BinInt String.
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.
 
 Section bsearch.
-  Context {p : unique! StringNames.Syntax.parameters} {b : BasicALU.operations}.
+  Context {p : unique! StringNames_parameters} {b : BasicALU.operations}.
   Local Coercion literal (z : Z) : expr := expr.literal z.
   Local Coercion var (x : String.string) : expr := expr.var x.
 

--- a/bedrock2/src/Map/UnorderedList.v
+++ b/bedrock2/src/Map/UnorderedList.v
@@ -1,14 +1,14 @@
 Require Import bedrock2.Macros bedrock2.Map.
 Require Coq.Lists.List.
 
-Class parameters := {
+Class UnorderedList_parameters := {
   key : Type;
   value : Type;
   key_eqb : key -> key -> bool
 }.
 
 Section UnorderedList.
-  Context {p : unique! parameters}.
+  Context {p : unique! UnorderedList_parameters}.
   Local Definition put m (k:key) (v:value) := (cons (k, v) (List.filter (fun p => negb (key_eqb k (fst p))) m)).
   Instance map : map key value := {|
     map.rep := list (key * value);
@@ -24,5 +24,5 @@ End UnorderedList.
 Arguments map : clear implicits.
 (* test of putmany *)
 Goal False.
-  assert (Map.map.putmany (0::0::nil)%list (4::7::nil)%list (@map.empty nat nat (map (Build_parameters nat nat Nat.eqb))) = Some ((0, 7) :: nil)%list) by reflexivity.
+  assert (Map.map.putmany (0::0::nil)%list (4::7::nil)%list (@map.empty nat nat (map (Build_UnorderedList_parameters nat nat Nat.eqb))) = Some ((0, 7) :: nil)%list) by reflexivity.
 Abort.

--- a/bedrock2/src/Semantics.v
+++ b/bedrock2/src/Semantics.v
@@ -1,8 +1,8 @@
 Require Import bedrock2.Macros bedrock2.Notations bedrock2.Syntax bedrock2.Map.
 Require Import Coq.ZArith.BinIntDef.
 
-Class parameters := {
-  syntax :> Syntax.parameters;
+Class Semantics_parameters := {
+  syntax :> Syntax_parameters;
 
   word : Set;
   word_zero : word;
@@ -23,7 +23,7 @@ Class parameters := {
 }.
 
 Section semantics.
-  Context {pp : unique! parameters}.
+  Context {pp : unique! Semantics_parameters}.
   
   Fixpoint load_rec (sz : nat) (m:mem) (a:word) : option word :=
     match sz with

--- a/bedrock2/src/StringNames.v
+++ b/bedrock2/src/StringNames.v
@@ -2,17 +2,16 @@ Require Import bedrock2.Syntax.
 
 Require Import Coq.Strings.String.
 
-Module Syntax.
-  Class parameters := {
-    actname : Set;
-    bopname : Set;
-  }.
+Class StringNames_parameters := {
+  actname : Set;
+  bopname : Set;
+}.
 
-  Global Instance make (p : parameters) : bedrock2.Syntax.parameters := {|
-    bedrock2.Syntax.varname := string;
-    bedrock2.Syntax.funname := string;
+Instance StringNames_to_Syntax_parameters (p : StringNames_parameters)
+: Syntax_parameters := {|
+  Syntax.varname := string;
+  Syntax.funname := string;
 
-    bedrock2.Syntax.actname := actname;
-    bedrock2.Syntax.bopname := bopname;
-  |}.
-End Syntax.
+  Syntax.actname := actname;
+  Syntax.bopname := bopname;
+|}.

--- a/bedrock2/src/Syntax.v
+++ b/bedrock2/src/Syntax.v
@@ -2,7 +2,7 @@ Require Import bedrock2.Macros.
 
 Require Import Coq.Numbers.BinNums.
   
-Class parameters := {
+Class Syntax_parameters := {
   varname : Set;
   funname : Set;
   actname : Set;
@@ -11,7 +11,7 @@ Class parameters := {
 
 
 Module expr. Section expr.
-  Context {p : unique! parameters}.
+  Context {p : unique! Syntax_parameters}.
   Inductive expr  : Type :=
   | literal (v: Z)
   | var (x: varname)
@@ -20,7 +20,7 @@ Module expr. Section expr.
 End expr. End expr. Notation expr := expr.expr.
 
 Module cmd. Section cmd.
-  Context {p : unique! parameters}.
+  Context {p : unique! Syntax_parameters}.
   Inductive cmd :=
   | skip
   | set (lhs : varname) (rhs : expr)

--- a/bedrock2/src/ToCString.v
+++ b/bedrock2/src/ToCString.v
@@ -3,8 +3,8 @@ Require Import bedrock2.Macros bedrock2.Syntax bedrock2.Variables.
 Require Import Coq.Numbers.BinNums.
 Require Import Coq.Strings.String.
 
-Class parameters := {
-  syntax :> Syntax.parameters;
+Class ToCString_parameters := {
+  syntax :> Syntax_parameters;
   varname_eqb : varname -> varname -> bool;
   rename_away_from : varname -> list varname -> varname;
   c_lit : Z -> String.string;
@@ -15,7 +15,7 @@ Class parameters := {
 }.
 
 Section ToCString.
-  Context {p : unique! parameters}.
+  Context {p : unique! ToCString_parameters}.
   Definition LF : string := String (Coq.Strings.Ascii.Ascii false true false true false false false false) "".
   Local Open Scope string_scope.
 

--- a/bedrock2/src/Variables.v
+++ b/bedrock2/src/Variables.v
@@ -3,7 +3,7 @@ Require Import bedrock2.Macros bedrock2.Syntax.
 Require Import Coq.Lists.List.
 
 Module expr. Section expr. Import Syntax.expr.
-  Context {p : unique! Syntax.parameters}.
+  Context {p : unique! Syntax_parameters}.
   Fixpoint vars (e : expr) : list varname :=
     match e with
     | literal v => nil
@@ -14,7 +14,7 @@ Module expr. Section expr. Import Syntax.expr.
 End expr. End expr.
 
 Module cmd. Section cmd. Import Syntax.cmd.
-  Context {p : unique! Syntax.parameters}.
+  Context {p : unique! Syntax_parameters}.
   Fixpoint vars (c: cmd) : list varname := 
     match c with
     | skip => nil

--- a/bedrock2/src/WeakestPrecondition.v
+++ b/bedrock2/src/WeakestPrecondition.v
@@ -3,7 +3,7 @@ Require Import bedrock2.Syntax bedrock2.Semantics.
 Require Import Coq.ZArith.BinIntDef.
 
 Section WeakestPrecondition.
-  Context {p : unique! Semantics.parameters}.
+  Context {p : unique! Semantics_parameters}.
   Context (rely guarantee : trace -> Prop) (progress : trace -> trace -> Prop).
 
   Definition literal v post : Prop :=

--- a/bedrock2/src/WeakestPreconditionProperties.v
+++ b/bedrock2/src/WeakestPreconditionProperties.v
@@ -1,10 +1,11 @@
 Require Import bedrock2.Macros.
+Require Import bedrock2.Semantics.
 Require bedrock2.WeakestPrecondition.
 
 Require Import Coq.Classes.Morphisms.
 
 Section WeakestPrecondition.
-  Context {p : unique! Semantics.parameters}.
+  Context {p : unique! Semantics_parameters}.
 
   Ltac ind_on X :=
     intros;

--- a/compiler/src/Basic32Semantics.v
+++ b/compiler/src/Basic32Semantics.v
@@ -6,7 +6,7 @@ Require Import compiler.Op.
 Require Import riscv.MachineWidth32.
 Require bbv.Word.
 
-Instance Basic32Semantics: bedrock2.Semantics.parameters := {|
+Instance Basic32Semantics: Semantics_parameters := {|
   syntax := compiler.NamesInstance.Names;
   word := Word.word 32;
   interp_binop bop := eval_binop bop;

--- a/compiler/src/ExprImp.v
+++ b/compiler/src/ExprImp.v
@@ -17,7 +17,7 @@ Require Import compiler.Memory.
 
 Section ExprImp1.
 
-  Context {p : unique! Semantics.parameters}.
+  Context {p : unique! Semantics_parameters}.
 
   Notation mword := (@Semantics.word p).
   Context {MW: MachineWidth mword}.  
@@ -279,7 +279,7 @@ Ltac invert_eval_cmd :=
 
 Section ExprImp2.
 
-  Context {p : unique! Semantics.parameters}.
+  Context {p : unique! Semantics_parameters}.
 
   Notation mword := (@Semantics.word p).
   Context {MW: MachineWidth mword}.  

--- a/compiler/src/NamesInstance.v
+++ b/compiler/src/NamesInstance.v
@@ -2,9 +2,9 @@ Require Import Coq.ZArith.BinInt.
 Require Import bedrock2.Syntax.
 Require Import compiler.Op.
 
-Instance Names: bedrock2.Syntax.parameters := {|
-  bedrock2.Syntax.varname := Z;
-  bedrock2.Syntax.funname := Z;
-  bedrock2.Syntax.actname := Empty_set;
-  bedrock2.Syntax.bopname := binop;
+Instance Names: Syntax_parameters := {|
+  varname := Z;
+  funname := Z;
+  actname := Empty_set;
+  bopname := binop;
 |}.


### PR DESCRIPTION
Fixes https://github.com/mit-plv/bedrock2/issues/19.

@andres-erbsen is this acceptable for you? :wink: 

My main objection to the current naming is that `StringNames.v` overrides `Syntax.parameters`, whereas the naming in this PR just calls them `Syntax_parameters` or `StringNames_parameters`.