### PR TITLE
Import prim token notations before using them

### DIFF
--- a/bedrock2/src/BasicC64Semantics.v
+++ b/bedrock2/src/BasicC64Semantics.v
@@ -1,3 +1,4 @@
+Require Import Coq.NArith.BinNatDef.
 Require Import bedrock2.BasicC64Syntax bedrock2.Semantics.
 Require bedrock2.String bedrock2.Map.UnorderedList.
 Require bbv.Word.
@@ -22,7 +23,7 @@ Instance parameters : parameters := {|
     | bopname.slu => fun w s => Word.wlshift' w (shiftWidth s)
     | bopname.srs => fun w s => Word.wrshifta' w (shiftWidth s)
     | bopname.ltu => fun a b => if Word.wltb a b then Word.wone 64 else Word.wzero 64
-    | bopname.lts => fun a b => if Word.wsltb a b then Word.wone 64 else Word.wzero 64 
+    | bopname.lts => fun a b => if Word.wsltb a b then Word.wone 64 else Word.wzero 64
     | bopname.eq => fun a b => if Word.weq a b then Word.wone 64 else Word.wzero 64
     end;
   (* TODO: bedrock2.Byte, bedrock2.Word8 *)

--- a/bedrock2/src/Examples/StructAccess.v
+++ b/bedrock2/src/Examples/StructAccess.v
@@ -1,3 +1,4 @@
+Require Import Coq.Strings.String Coq.ZArith.BinIntDef.
 Require Import bedrock2.Syntax bedrock2.Structs bedrock2.NotationsInConstr.
 
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.

--- a/bedrock2/src/String.v
+++ b/bedrock2/src/String.v
@@ -1,2 +1,2 @@
-Require Import Coq.Strings.String.
+Require Export Coq.Strings.String.
 Definition eqb a b := andb (String.prefix a b) (String.prefix b a).

--- a/bedrock2/src/ToCString.v
+++ b/bedrock2/src/ToCString.v
@@ -1,6 +1,7 @@
 Require Import bedrock2.Macros bedrock2.Syntax bedrock2.Variables.
 
 Require Import Coq.Numbers.BinNums.
+Require Import Coq.ZArith.BinIntDef.
 Require Import Coq.Strings.String.
 
 Class parameters := {
@@ -30,7 +31,7 @@ Section ToCString.
 
   Fixpoint c_expr (e : expr) : string :=
     match e with
-    | expr.literal v => c_lit v 
+    | expr.literal v => c_lit v
     | expr.var x => c_var x
     | expr.load s ea => "*(" ++ c_size s ++ "*)(" ++ c_expr ea ++ ")"
     | expr.op op e1 e2 => c_bop ("(" ++ c_expr e1 ++ ")") op ("(" ++ c_expr e2 ++ ")")
@@ -52,7 +53,7 @@ Section ToCString.
     match args with
     | nil =>
       f ++ "(" ++ concat ", " es ++ ");" ++ LF
-    | ((x::_)%list as binds)  => 
+    | ((x::_)%list as binds)  =>
       List.last binds x ++ " = " ++ f ++ "(" ++ concat ", " (es ++ List.map (fun x => "&"++x) (List.removelast binds)) ++ ");" ++ LF
     end.
 


### PR DESCRIPTION
This is required for compatibility with
https://github.com/coq/coq/pull/8064, where prim token notations no longer
follow `Require`, but instead follow `Import`.

c.f. https://github.com/coq/coq/pull/8064#issuecomment-415493362

Closes #23 

I'm pretty sure this builds, but you should probably wait for the CI to be sure.