### PR TITLE
[do not merge] try to move bedrock2.BasicC64Syntax.BasicALU to a more generic place

### DIFF
--- a/bedrock2/src/BasicBopnamesSyntax.v
+++ b/bedrock2/src/BasicBopnamesSyntax.v
@@ -1,0 +1,23 @@
+Require bedrock2.Syntax.
+Require bedrock2.BasicALU.
+
+Module Import bopname.
+  Inductive bopname := add | sub | mul | and | or | xor | sru | slu | srs | lts | ltu | eq.
+End bopname.
+Notation bopname := bopname.bopname.
+
+Class parameters := {
+  varname: Set;
+  funcname: Set;
+  actname: Set;
+}.
+
+Instance make (p: parameters) : Syntax.parameters := {|
+  Syntax.varname := @varname p;
+  Syntax.funname := @funcname p;
+  Syntax.actname := @actname p;
+  Syntax.bopname := bopname;
+|}.
+
+Instance BasicALU{p: parameters}: BasicALU.operations :=
+  BasicALU.Build_operations _ add sub mul and or xor sru slu srs lts ltu eq.

--- a/bedrock2/src/BasicC64Semantics.v
+++ b/bedrock2/src/BasicC64Semantics.v
@@ -5,7 +5,7 @@ Require bbv.Word.
 
 Local Definition shiftWidth s := Word.wordToNat (Word.wand s (Word.NToWord 64 63)).
 Instance parameters : parameters := {|
-  syntax := StringNamesSyntax.make BasicC64Syntax.params;
+  syntax := BasicBopnamesSyntax.make BasicC64Syntax.params;
   word := Word.word 64;
   word_zero := Word.wzero 64;
   word_succ := Word.wplus (Word.wone 64);

--- a/bedrock2/src/BasicC64Syntax.v
+++ b/bedrock2/src/BasicC64Syntax.v
@@ -1,21 +1,22 @@
 Require Import bedrock2.Macros bedrock2.Syntax bedrock2.ToCString.
-Require Import bedrock2.StringNamesSyntax bedrock2.BasicALU bedrock2.String.
+Require Import bedrock2.BasicALU bedrock2.String.
 
 Require Import Coq.Strings.String Coq.Numbers.DecimalZ Coq.Numbers.DecimalString.
 
-Require Export bedrock2.Basic_bopnames.
-Import bedrock2.Basic_bopnames.bopname.
+Require Export bedrock2.BasicBopnamesSyntax.
+Import bedrock2.BasicBopnamesSyntax.bopname.
 
-Definition params : bedrock2.StringNamesSyntax.parameters := {|
-  StringNamesSyntax.bopname := bedrock2.Basic_bopnames.bopname;
-  StringNamesSyntax.actname := string
+(* TODO we should reuse StringNamesSyntax here, but we have a diamond problem *)
+Definition params : BasicBopnamesSyntax.parameters := {|
+  BasicBopnamesSyntax.varname := string;
+  BasicBopnamesSyntax.funcname := string;
+  BasicBopnamesSyntax.actname := string;
 |}.
 
-Definition BasicALU : BasicALU.operations :=
-  Build_operations (StringNamesSyntax.make params) add sub mul and or xor sru slu srs lts ltu eq.
+Definition BasicALU : BasicALU.operations := @BasicBopnamesSyntax.BasicALU params.
 
 Definition to_c_parameters : ToCString.parameters := {|
-  syntax := (StringNamesSyntax.make params);
+  syntax := BasicBopnamesSyntax.make params;
   c_lit w := DecimalString.NilZero.string_of_int (BinInt.Z.to_int w) ++ "ULL";
   c_bop := fun e1 op e2 =>
              match op with

--- a/bedrock2/src/Basic_bopnames.v
+++ b/bedrock2/src/Basic_bopnames.v
@@ -1,4 +1,0 @@
-Module bopname.
-  Inductive bopname := add | sub | mul | and | or | xor | sru | slu | srs | lts | ltu | eq.
-End bopname.
-Notation bopname := bopname.bopname.

--- a/bedrock2/src/Examples/ListSum.v
+++ b/bedrock2/src/Examples/ListSum.v
@@ -1,0 +1,32 @@
+Require Import bedrock2.Macros bedrock2.Syntax.
+Require Import bedrock2.ZNamesSyntax bedrock2.BasicALU bedrock2.NotationsInConstr.
+Require Import Coq.ZArith.BinInt.
+
+Local Open Scope Z_scope.
+
+(* TODO make varname abstract so that it doesn't clash with the Lit coercion,
+   and also abstract over fresh name generation. *)
+Section listsum.
+  Context {b : BasicALU.operations}.
+  
+  Local Coercion Lit (z: Z): expr := expr.literal z.
+  Local Coercion Var (x: varname): expr := expr.var x.
+
+  Let n: varname := 1.
+  Let i: varname := 2.
+  Let sumreg: varname := 3.
+  Let a: varname := 4.
+
+  (* input_base is an address fixed at compilation time *)
+  Definition listsum(input_base: Z) := bedrock_func_body:(
+    sumreg = 0;
+    n = *(uint32_t*) input_base;
+    i = 0;
+    while (Var i < Var n) {{
+      a = *(uint32_t*) ((input_base + 4)%Z + (4 * Var i));
+      sumreg = Var sumreg + Var a;
+      i = Var i + 1
+    }}
+  ).
+
+End listsum.

--- a/bedrock2/src/Examples/MultipleReturnValues.v
+++ b/bedrock2/src/Examples/MultipleReturnValues.v
@@ -1,5 +1,5 @@
 Require Import bedrock2.Macros bedrock2.Syntax.
-Require Import bedrock2.StringNamesSyntax bedrock2.BasicALU bedrock2.NotationsInConstr.
+Require Import bedrock2.BasicBopnamesSyntax bedrock2.BasicALU bedrock2.NotationsInConstr.
 
 Import BinInt String.
 Local Open Scope string_scope. Local Open Scope Z_scope. Local Open Scope list_scope.

--- a/bedrock2/src/NotationsInConstr.v
+++ b/bedrock2/src/NotationsInConstr.v
@@ -87,7 +87,8 @@ Notation "e1 << e2" := (expr.op bop_slu e1%bedrock_expr e2%bedrock_expr)
 
 Notation "e1 .& e2" := (expr.op bop_and e1%bedrock_expr e2%bedrock_expr)
   (at level 40, left associativity) : bedrock_expr.
-(* same level:   *    *)
+Notation "e1 * e2" := (expr.op bop_mul e1%bedrock_expr e2%bedrock_expr)
+  (at level 40, left associativity) : bedrock_expr.
 
 (* FIXME: intermediate level for  %  /  *)
 

--- a/bedrock2/src/ZNamesSyntax.v
+++ b/bedrock2/src/ZNamesSyntax.v
@@ -1,6 +1,6 @@
 Require Import Coq.ZArith.ZArith.
 Require Import bedrock2.Syntax.
-Require Import bedrock2.Basic_bopnames.
+Require Import bedrock2.BasicBopnamesSyntax.
 
 Instance ZNames : Syntax.parameters := {|
   Syntax.varname := Z;

--- a/compiler/src/examples/ListSum.v
+++ b/compiler/src/examples/ListSum.v
@@ -4,7 +4,6 @@ Local Open Scope word_scope.
 Require Import compiler.ExprImp.
 Require Import riscv.util.BitWidths.
 Require Import compiler.util.Common.
-Require compiler.ExprImpNotations.
 Require Import Coq.Lists.List.
 Import ListNotations.
 Require Import riscv.util.Word.
@@ -19,7 +18,7 @@ Require Import compiler.examples.Fibonacci.
 Require Import compiler.NameGen.
 Require Import riscv.MachineWidth32.
 Require Import riscv.util.BitWidth32.
-
+Require bedrock2.Examples.ListSum.
 
 Local Notation RiscvMachine := (@RiscvMachine (word 32) mem state).
 
@@ -27,11 +26,13 @@ Definition memory_size: Z := 1024.
 Definition instructionMemStart: Z := 0.
 Definition input_base: Z := 512.
 
+Definition listsum := bedrock2.Examples.ListSum.listsum input_base.
 
 Module ExampleSrc.
 
-  Import ExprImpNotations. (* only inside this module *)
-  
+  Import bedrock2.NotationsInConstr. (* only inside this module *)
+
+  Print listsum.
   Definition n: var := 1.
   Definition i: var := 2.
   Definition sumreg: var := 3.


### PR DESCRIPTION
`bedrock2.BasicC64Syntax` contains the following definition:

```
Definition BasicALU : BasicALU.operations :=
  Build_operations (StringNamesSyntax.make params) add sub mul and or xor sru slu srs lts ltu eq.
```

I wanted to make it abstract over the syntax parameters, so that I can use a `BasicALU.operations` in places where I don't want to commit to a bitwidth or to a varname/funcname representation.

However, I completely failed, and this PR shows what I tried so far.
Overall, I'm confused. Advice by @andres-erbsen would be appreciated :wink: