### PR TITLE
Proposal: Globals (pre-cursor to Compilation Units)

### DIFF
--- a/bedrock2/src/BasicC64Semantics.v
+++ b/bedrock2/src/BasicC64Semantics.v
@@ -33,5 +33,5 @@ Instance parameters : parameters := {|
   (* TODO: faster maps *)
   mem := UnorderedList.map {| UnorderedList.key_eqb a b := if Word.weq a b then true else false |};
   locals := UnorderedList.map {| UnorderedList.key_eqb := String.eqb |};
-  funname_eqb := String.eqb;
+  globname_eqb := String.eqb;
 |}.

--- a/bedrock2/src/BasicC64Syntax.v
+++ b/bedrock2/src/BasicC64Syntax.v
@@ -33,7 +33,7 @@ Definition to_c_parameters : ToCString.parameters := {|
              | eq => e1++"=="++e2
              end%string;
      c_var := id;
-     c_fun := id;
+     c_glob := id;
      c_act := ToCString.c_call;
 
      varname_eqb := String.eqb;

--- a/bedrock2/src/Examples/Swap.v
+++ b/bedrock2/src/Examples/Swap.v
@@ -16,8 +16,8 @@ Section bsearch.
   )).
 
   Definition swap_swap : list varname * list varname * cmd := (("a"::"b"::nil), nil, bedrock_func_body:(
-    cmd.call nil "swap" (var "a"::var "b"::nil);
-    cmd.call nil "swap" (var "a"::var "b"::nil)
+    cmd.call nil (expr.global "swap") (var "a"::var "b"::nil);
+    cmd.call nil (expr.global "swap") (var "a"::var "b"::nil)
   )).
 End bsearch.
 
@@ -92,10 +92,10 @@ end.
 
 Context (__A : map.ok Semantics.mem).
 Lemma swap_ok : 
-  forall a_addr a b_addr b (m:map.rep (value:=@Semantics.byte _)) R t,
+  forall l a_addr a b_addr b (m:map.rep (value:=@Semantics.byte _)) R t,
     (sep (ptsto 1 a_addr a) (sep (ptsto 1 b_addr b) R)) m ->
   WeakestPrecondition.func
-    (fun _ => True) (fun _ => False) (fun _ _ => True) (fun _ _ _ _ _ => False)
+    (fun _ => True) (fun _ => False) (fun _ _ => True) l (fun _ _ _ _ _ => False)
     (@swap BasicC64Syntax.params) t m (a_addr::b_addr::nil)
     (fun t' m' rets => t=t' /\ (sep (ptsto 1 a_addr b) (sep (ptsto 1 b_addr a) R)) m' /\ rets = nil).
 Proof.
@@ -104,13 +104,14 @@ Proof.
 Qed.
 
 Lemma swap_swap_ok : 
-  forall a_addr a b_addr b (m:map.rep (value:=@Semantics.byte _)) R t,
+  forall l a_addr a b_addr b (m:map.rep (value:=@Semantics.byte _)) R t,
     (sep (ptsto 1 a_addr a) (sep (ptsto 1 b_addr b) R)) m ->
   WeakestPrecondition.func
-    (fun _ => True) (fun _ => False) (fun _ _ => True) (WeakestPrecondition.call (fun _ => True) (fun _ => False) (fun _ _ => True) [("swap", (@swap BasicC64Syntax.params))])
+    (fun _ => True) (fun _ => False) (fun _ _ => True) l (WeakestPrecondition.call (fun _ => True) (fun _ => False) (fun _ _ => True) l [("swap", (@swap BasicC64Syntax.params))])
     (@swap_swap BasicC64Syntax.params) t m (a_addr::b_addr::nil)
     (fun t' m' rets => t=t' /\ (sep (ptsto 1 a_addr a) (sep (ptsto 1 b_addr b) R)) m' /\ rets = nil).
 Proof.
+  Print WeakestPrecondition.func.
   intros. rename H into Hm.
   eexists.
   eexists.
@@ -121,6 +122,7 @@ Proof.
   eexists.
   eexists.
   eexists.
+  unfold WeakestPrecondition.list_map.
   intros. eapply WeakestPreconditionProperties.Proper_func.
   6: eapply swap_ok.
   1,2,3,4,5 : cbv [Morphisms.pointwise_relation trace Basics.flip Basics.impl Morphisms.respectful]; try solve [typeclasses eauto with core].

--- a/bedrock2/src/Semantics.v
+++ b/bedrock2/src/Semantics.v
@@ -19,12 +19,12 @@ Class parameters := {
   mem :> map word byte;
   locals :> map varname word;
 
-  funname_eqb : funname -> funname -> bool
+  globname_eqb : globname -> globname -> bool
 }.
 
 Section semantics.
   Context {pp : unique! parameters}.
-  
+
   Fixpoint load_rec (sz : nat) (m:mem) (a:word) : option word :=
     match sz with
     | O => Some word_zero

--- a/bedrock2/src/StringNamesSyntax.v
+++ b/bedrock2/src/StringNamesSyntax.v
@@ -9,7 +9,7 @@ Class parameters := {
 
 Instance make (p : parameters) : Syntax.parameters := {|
   Syntax.varname := string;
-  Syntax.funname := string;
+  Syntax.globname := string;
 
   Syntax.actname := actname;
   Syntax.bopname := bopname;

--- a/bedrock2/src/Syntax.v
+++ b/bedrock2/src/Syntax.v
@@ -4,7 +4,7 @@ Require Import Coq.Numbers.BinNums.
   
 Class parameters := {
   varname : Set;
-  funname : Set;
+  globname : Set;
   actname : Set;
   bopname : Set;
 }.
@@ -15,6 +15,7 @@ Module expr. Section expr.
   Inductive expr  : Type :=
   | literal (v: Z)
   | var (x: varname)
+  | global (_ : globname)
   | load (access_size_in_bytes:Z) (addr:expr)
   | op (op: bopname) (e1 e2: expr).
 End expr. End expr. Notation expr := expr.expr.
@@ -28,6 +29,6 @@ Module cmd. Section cmd.
   | cond (condition : expr) (nonzero_branch zero_branch : cmd)
   | seq (s1 s2: cmd)
   | while (test : expr) (body : cmd)
-  | call (binds : list varname) (function : funname) (args: list expr)
+  | call (binds : list varname) (function : expr) (args: list expr)
   | interact (binds : list varname) (action : actname) (args: list expr).
 End cmd. End cmd. Notation cmd := cmd.cmd.

--- a/bedrock2/src/ToCString.v
+++ b/bedrock2/src/ToCString.v
@@ -11,7 +11,7 @@ Class parameters := {
   c_lit : Z -> String.string;
   c_bop : string -> bopname -> string -> string;
   c_var : varname -> String.string;
-  c_fun : funname -> String.string;
+  c_glob : globname -> String.string;
   c_act : list varname -> actname -> list String.string -> string;
 }.
 
@@ -33,6 +33,7 @@ Section ToCString.
     match e with
     | expr.literal v => c_lit v
     | expr.var x => c_var x
+    | expr.global x => c_glob x
     | expr.load s ea => "*(" ++ c_size s ++ "*)(" ++ c_expr ea ++ ")"
     | expr.op op e1 e2 => c_bop ("(" ++ c_expr e1 ++ ")") op ("(" ++ c_expr e2 ++ ")")
     end.
@@ -79,13 +80,13 @@ Section ToCString.
     | cmd.skip =>
       indent ++ "/*skip*/" ++ LF
     | cmd.call args f es =>
-      indent ++ c_call (List.map c_var args) (c_fun f) (List.map c_expr es)
+      indent ++ c_call (List.map c_var args) (c_expr f) (List.map c_expr es)
     | cmd.interact binds action es =>
       indent ++ c_act binds action (List.map c_expr es)
     end%string.
 
-  Definition c_decl (rett : string) (args : list varname) (name : funname) (retptrs : list varname) : string :=
-    (rett ++ " " ++ c_fun name ++ "(" ++ concat ", " (
+  Definition c_decl (rett : string) (args : list varname) (name : globname) (retptrs : list varname) : string :=
+    (rett ++ " " ++ c_glob name ++ "(" ++ concat ", " (
                     List.map (fun a => "uintptr_t "++c_var a) args ++
                     List.map (fun r => "uintptr_t* "++c_var r) retptrs) ++
                   ")")%string.

--- a/bedrock2/src/Variables.v
+++ b/bedrock2/src/Variables.v
@@ -6,8 +6,9 @@ Module expr. Section expr. Import Syntax.expr.
   Context {p : unique! Syntax.parameters}.
   Fixpoint vars (e : expr) : list varname :=
     match e with
-    | literal v => nil
+    | literal _ => nil
     | var x => cons x nil
+    | global _ => nil
     | load _ ea => vars ea
     | op _ e1 e2 => List.app (vars e1) (vars e2)
     end.

--- a/bedrock2/src/WeakestPreconditionProperties.v
+++ b/bedrock2/src/WeakestPreconditionProperties.v
@@ -24,7 +24,9 @@ Section WeakestPrecondition.
   Global Instance Proper_store : Proper (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ ((pointwise_relation _ Basics.impl) ==> Basics.impl))))) WeakestPrecondition.store.
   Proof. cbv [WeakestPrecondition.load]; cbv [Proper respectful pointwise_relation Basics.impl]; firstorder idtac. Qed.
 
-  Global Instance Proper_expr : Proper (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ ((pointwise_relation _ Basics.impl) ==> Basics.impl)))) WeakestPrecondition.expr.
+(*
+  Global Instance Proper_expr
+  : Proper (pointwise_relation _ (pointwise_relation _ (pointwise_relation _ ((pointwise_relation _ Basics.impl) ==> Basics.impl)))) WeakestPrecondition.expr.
   Proof.
     cbv [Proper respectful pointwise_relation Basics.impl]; ind_on Syntax.expr.expr;
       cbn in *; intuition (try typeclasses eauto with core).
@@ -32,6 +34,7 @@ Section WeakestPrecondition.
     eapply Proper_get; eauto.
     { eapply IHa1; eauto; intuition idtac. eapply Proper_load; eauto using Proper_load. }
   Qed.
+*)
 
   Global Instance Proper_list_map {A B} :
     Proper ((pointwise_relation _ (pointwise_relation _ Basics.impl ==> Basics.impl)) ==> pointwise_relation _ (pointwise_relation _ Basics.impl ==> Basics.impl)) (WeakestPrecondition.list_map (A:=A) (B:=B)).
@@ -39,7 +42,8 @@ Section WeakestPrecondition.
     cbv [Proper respectful pointwise_relation Basics.impl]; ind_on (list A);
       cbn in *; intuition (try typeclasses eauto with core).
   Qed.
- 
+
+(* 
   Global Instance Proper_cmd :
     Proper (
      (pointwise_relation _ (Basics.flip Basics.impl)) ==> (
@@ -167,4 +171,5 @@ Section WeakestPrecondition.
     try solve [typeclasses eauto with core].
     eauto.
   Qed.
+*)
 End WeakestPrecondition.

--- a/bedrock2/src/ZNamesSyntax.v
+++ b/bedrock2/src/ZNamesSyntax.v
@@ -4,7 +4,7 @@ Require Import bedrock2.Basic_bopnames.
 
 Instance ZNames : Syntax.parameters := {|
   Syntax.varname := Z;
-  Syntax.funname := Z;
+  Syntax.globname := Z;
 
   Syntax.actname := Empty_set;
   Syntax.bopname := bopname;


### PR DESCRIPTION
This generalizes functions into globals. It still doesn't support function pointers though doing so is relatively simple. In summary,

```coq
funname -> globname

expr := ..
  | global (_ : globname)
```

Because it was simple, I also changed `call` from taking a `funname` to taking an `expr` (so `f` becomes `global f`). Generalizing the semantics completely isn't too difficult. I can add that to this PR if it would be useful. #27 is preventing a complete operational semantics, but if we solve that, it shouldn't be difficult to do this.
