### PR TITLE
implement cmd.unset for declaring a variable dead

### DIFF
--- a/bedrock2/src/Examples/ipow.v
+++ b/bedrock2/src/Examples/ipow.v
@@ -50,9 +50,11 @@ Local Coercion var (x : string) : expr := expr.var x.
 Definition ipow := ("ipow", (["x";"e"], (["ret"]:list varname), bedrock_func_body:(
   "ret" = 1;;
   while ("e") {{
-    if ("e" .& 1) {{ "ret" = "ret" * "x" }};;
+    "t" = "e" .& 1;;
+    if ("t") {{ "ret" = "ret" * "x" }};;
     "e" = "e" >> 1;;
-    "x" = "x" * "x"
+    "x" = "x" * "x";;
+    cmd.unset "t"
   }}
 ))).
 

--- a/bedrock2/src/Map.v
+++ b/bedrock2/src/Map.v
@@ -5,6 +5,7 @@ Module map.
     empty : rep;
     get : rep -> key -> option value;
     put : rep -> key -> value -> rep;
+    remove : rep -> key -> rep;
     union : rep -> rep -> rep; (* rightmost takes priority *)
   }.
   Arguments map : clear implicits.
@@ -14,6 +15,8 @@ Module map.
     get_empty : forall k, get empty k = None;
     get_put_same : forall m k v, get (put m k v) k = Some v;
     get_put_diff : forall m k v k', k <> k' -> get (put m k' v) k = get m k;
+    get_remove_same : forall m k, get (remove m k) k = None;
+    get_remove_diff : forall m k k', k <> k' -> get (remove m k') k = get m k;
     get_union_left : forall m1 m2 k, get m2 k = None -> get (union m1 m2) k = get m1 k;
     get_union_right : forall m1 m2 k v, get m2 k = Some v -> get (union m1 m2) k = Some v;
   }.

--- a/bedrock2/src/Map/SortedList.v
+++ b/bedrock2/src/Map/SortedList.v
@@ -33,6 +33,17 @@ Section UnorderedList.
         then cons (k, v) m
         else cons (k', v') (put m' k v)
     end.
+  Fixpoint remove m (k:key) : list (key * value) :=
+    match m with
+    | nil => nil
+    | cons (k', v') m' =>
+      if key_eqb k k'
+      then m'
+      else 
+        if key_ltb k k'
+        then m
+        else cons (k', v') (remove m' k)
+    end.
   Fixpoint sorted (m : list (key * value)) :=
     match m with
     | cons (k1, _) ((cons (k2, _) m'') as m') => andb (key_ltb k1 k2) (sorted m')
@@ -40,8 +51,10 @@ Section UnorderedList.
     end.
   Record rep := { value : list (key * value) ; ok : sorted value = true }.
   Lemma sorted_put m k v : sorted m = true -> sorted (put m k v) = true. Admitted.
+  Lemma sorted_remove m k : sorted m = true -> sorted (remove m k) = true. Admitted.
   Definition map : map key parameters.value :=
     let wrapped_put m k v := Build_rep (put (value m) k v) (minimize_eq_proof Bool.bool_dec (sorted_put _ _ _ (ok m))) in
+    let wrapped_remove m k := Build_rep (remove (value m) k) (minimize_eq_proof Bool.bool_dec (sorted_remove _ _ (ok m))) in
     {|
     map.rep := rep;
     map.empty := Build_rep nil eq_refl;
@@ -50,6 +63,7 @@ Section UnorderedList.
                    | None => None
                    end;
     map.put := wrapped_put;
+    map.remove := wrapped_remove;
     map.union m1 m2 := List.fold_right (fun '(k, v) m => wrapped_put m k v) m1 (value m2)
   |}.
 

--- a/bedrock2/src/Map/UnorderedList.v
+++ b/bedrock2/src/Map/UnorderedList.v
@@ -9,7 +9,8 @@ Class parameters := {
 
 Section UnorderedList.
   Context {p : unique! parameters}.
-  Local Definition put m (k:key) (v:value) := (cons (k, v) (List.filter (fun p => negb (key_eqb k (fst p))) m)).
+  Local Definition remove (m:list(key*value)) k := List.filter (fun p => negb (key_eqb k (fst p))) m.
+  Local Definition put m (k:key) (v:value) := cons (k, v) (remove m k).
   Instance map : map key value := {|
     map.rep := list (key * value);
     map.empty := nil;
@@ -18,6 +19,7 @@ Section UnorderedList.
                    | None => None
                    end;
     map.put := put;
+    map.remove := remove;
     map.union := List.fold_right (fun '(k, v) m => put m k v)
   |}.
 End UnorderedList.

--- a/bedrock2/src/Syntax.v
+++ b/bedrock2/src/Syntax.v
@@ -25,6 +25,7 @@ Module cmd. Section cmd.
   Inductive cmd :=
   | skip
   | set (lhs : varname) (rhs : expr)
+  | unset (lhs : varname)
   | store (size_in_bytes : Z) (address : expr) (value : expr)
   | cond (condition : expr) (nonzero_branch zero_branch : cmd)
   | seq (s1 s2: cmd)

--- a/bedrock2/src/ToCString.v
+++ b/bedrock2/src/ToCString.v
@@ -64,6 +64,8 @@ Section ToCString.
       => indent ++ "*("++c_size s++"*)(" ++ c_expr ea ++ ") = " ++ c_expr ev ++ ";" ++ LF
     | cmd.set x ev =>
       indent ++ c_var x ++ " = " ++ c_expr ev ++ ";" ++ LF
+    | cmd.unset x =>
+      indent ++ "// unset " ++ c_var x ++ LF
     | cmd.cond eb t f =>
       indent ++ "if (" ++ c_expr eb ++ ") {" ++ LF ++
         c_cmd ("  "++indent) t ++

--- a/bedrock2/src/Variables.v
+++ b/bedrock2/src/Variables.v
@@ -19,6 +19,7 @@ Module cmd. Section cmd. Import Syntax.cmd.
     match c with
     | skip => nil
     | set x e => x::expr.vars e
+    | unset x => x::nil
     | store _ ea ev => expr.vars ea ++ expr.vars ev
     | cond eb ct cf => expr.vars eb ++ (vars ct ++ vars cf)
     | seq c1 c2 => vars c1 ++ vars c2

--- a/bedrock2/src/WeakestPrecondition.v
+++ b/bedrock2/src/WeakestPrecondition.v
@@ -60,6 +60,9 @@ Section WeakestPrecondition.
         bind_ex v <- dexpr m l ev;
         let l := map.put l x v in
         post t m l
+      | cmd.unset x =>
+        let l := map.remove l x in
+        post t m l
       | cmd.store sz ea ev =>
         bind_ex a <- dexpr m l ea;
         bind_ex v <- dexpr m l ev;

--- a/compiler/src/FlattenExpr.v
+++ b/compiler/src/FlattenExpr.v
@@ -109,7 +109,7 @@ Section FlattenExpr.
         let '(s1', ngs') := flattenStmt ngs s1 in
         let '(s2', ngs'') := flattenStmt ngs' s2 in
         (FlatImp.SSeq s1' s2', ngs'')
-    | Syntax.cmd.skip => (FlatImp.SSkip, ngs)
+    | Syntax.cmd.skip | Syntax.cmd.unset _ => (FlatImp.SSkip, ngs)
     | Syntax.cmd.call binds f args => flattenCall ngs binds f args
     | Syntax.cmd.interact _ _ _ => (FlatImp.SSkip, ngs) (* unsupported *)
     end.
@@ -453,6 +453,11 @@ Section FlattenExpr.
       + clear IHfuelH.
         pose_flatten_var_ineqs.
         state_calc.
+    - simpl in F. inversions F. destruct_pair_eqs.
+      exists 1%nat initialL. split. solve [auto]. subst.
+      { cbv [extends]. intros k v. rewrite get_remove_key.
+        destruct_one_match; try discriminate; []. auto. }
+      SearchAbout remove_key.
     - repeat (inversionss; try destruct_one_match_hyp).
       match goal with
       | Ev: ExprImp.eval_expr _ _ = Some _ |- _ =>


### PR DESCRIPTION
we would prove a lemma that if a program is good with unset, it is also good without unset. Then we would write an unverified thing to insert unset at locations where a variable becomes dead. each program logic proof would start by replacing the original program with the annotated program using the lemma.