### PR TITLE
sketch squarer program with IO

### DIFF
--- a/bedrock2/src/Examples/Trace.v
+++ b/bedrock2/src/Examples/Trace.v
@@ -1,0 +1,124 @@
+Require Import Coq.ZArith.ZArith. Open Scope Z_scope.
+Require Import Coq.Lists.List. Import ListNotations.
+Require Import coqutil.Word.Interface.
+Require Import coqutil.Map.Interface.
+Require Import bedrock2.ListPred. Import ListPredNotations.
+Require Import bedrock2.Semantics.
+
+(*Require Import bedrock2.BasicC64Syntax.*)
+Require Import bedrock2.Syntax.
+(*Local Existing Instance bedrock2.BasicC64Syntax.StringNames_params.*)
+
+
+(* TODO distribute contents of this file into the right places *)
+
+Section Squarer.
+
+  Context {p: Semantics.parameters}.
+
+  Definition Event: Type := (mem * actname * list word) * (mem * list word).
+
+  Context (read_word: word -> list Event -> Prop).
+  Context (write_word: word -> list Event -> Prop).
+
+  Definition squarer_trace: list Event -> Prop :=
+    (existsl (fun inp => read_word inp +++ write_word (word.mul inp inp))) ^*.
+
+  Definition squarer: Syntax.cmd. Admitted.
+
+  Lemma squarer_correct: forall (m: mem) (l: locals),
+      exec map.empty squarer nil m l (fun t' m' l' => squarer_trace t').
+  Admitted.
+
+End Squarer.
+
+
+(* TODO: on which side of the list do we add new events? *)
+
+Module SpiEth.
+
+  Inductive actname := MMInput | MMOutput.
+
+  Section WithMem.
+    Context {byte: word.word 8} {word: word.word 32} {mem: map.map word byte}.
+    (* Context {mem: Type}. *)
+
+    Definition Event: Type := (mem * actname * list word) * (mem * list word).
+
+    Definition msb_set(x: word): Prop :=
+      word.and x (word.slu (word.of_Z 1) (word.of_Z 31)) <> word.of_Z 0.
+
+    Definition lo_byte(x: word): word :=
+      word.and x (word.of_Z 255).
+
+    (* TODO hex notation *)
+    Definition spi_rx     : word := word.of_Z 268582988. (* 0x1002404c *)
+    Definition spi_tx_fifo: word := word.of_Z 268582984. (* 0x10024048 *)
+
+    (*  // Reads one byte over SPI and returns
+        static inline w spi_read() {
+            w x = -1;
+            while (x & (1 << 31)) { x = MMIO(0x1002404c); } // spi rx
+            return x&0xff;
+        }
+    TODO would there be any benefit in using kleene for this? If so, how to do it? *)
+    Inductive read_byte: word -> list Event -> Prop :=
+    | read_byte_go: forall x m,
+        ~ msb_set x ->
+        read_byte (lo_byte x) [((m, MMInput, [spi_rx]), (m, [x]))]
+    | read_byte_wait: forall x y m rest,
+        msb_set x ->
+        read_byte y rest ->
+        read_byte y (((m, MMInput, [spi_rx]), (m, [x])) :: rest).
+
+    (*  // Requires b < 256
+        static inline void spi_write(w b) {
+            while (MMIO(0x10024048) & (1 << 31)) {} // high order bit set means fifo is full
+            MMIO(0x10024048) = b; // spi tx fifo
+        }
+    *)
+    Inductive write_byte: word -> list Event -> Prop :=
+    | write_byte_go: forall x b m,
+        ~ msb_set x ->
+        0 <= b < 256 ->
+        write_byte (word.of_Z b) [((m, MMInput, [spi_tx_fifo]), (m, [x]));
+                                  ((m, MMOutput, [spi_tx_fifo; word.of_Z b]), (m, []))]
+    | write_byte_wait: forall x b m rest,
+        msb_set x ->
+        write_byte b rest ->
+        write_byte b (((m, MMInput, [spi_tx_fifo]), (m, [x])) :: rest).
+
+  End WithMem.
+End SpiEth.
+
+
+Module Syscalls.
+
+  Inductive actname := Syscall.
+
+  (* Go models syscalls as
+     func Syscall(trap, a1, a2, a3 uintptr) (r1, r2 uintptr, err Errno)
+     so we will have syscalls with 4 word arguments and 3 word return values *)
+
+  Section WithMem.
+    Context {byte: word.word 8} {word: word.word 32} {mem: map.map word byte}.
+    (* Context {mem: Type}. *)
+
+    Definition Event: Type := (mem * actname * list word) * (mem * list word).
+
+    Definition magicValue: word. Admitted.
+
+    (* TODO what about failures? *)
+    (* TODO what if the syscall changes the memory? Do we see the whole memory? *)
+    Inductive read_word: word -> list Event -> Prop :=
+    | read_word_go: forall m x ret2 err,
+        read_word x [((m, Syscall, [magicValue; magicValue; magicValue; magicValue]),
+                      (m, [x; ret2; err]))].
+
+    Inductive write_word: word -> list Event -> Prop :=
+    | write_word_go: forall m x ret1 ret2 err,
+        write_word x [((m, Syscall, [x; magicValue; magicValue; magicValue]),
+                       (m, [ret1; ret2; err]))].
+
+  End WithMem.
+End Syscalls.

--- a/bedrock2/src/Lift1Prop.v
+++ b/bedrock2/src/Lift1Prop.v
@@ -1,7 +1,15 @@
 Require Import Coq.Classes.Morphisms.
-Definition impl1 {T} (P Q:_->Prop) : Prop := forall x:T, P x -> Q x.
-Definition iff1 {T} (P Q:_->Prop) : Prop := forall x:T, P x <-> Q x.
+
+Section Binary.
+  Context {T: Type} (P Q: T -> Prop).
+  Definition impl1 := forall x, P x -> Q x.
+  Definition iff1 := forall x, P x <-> Q x.
+  Definition and1 := forall x, P x /\ Q x.
+  Definition or1 := forall x, P x \/ Q x.
+End Binary.
+
 Definition ex1 {A B} (P : A -> B -> Prop) := fun (b:B) => exists a:A, P a b.
+
 Global Instance Transitive_impl1 T : Transitive (@impl1 T). firstorder idtac. Qed.
 Global Instance Reflexive_impl1 T : Reflexive (@impl1 T). firstorder idtac. Qed.
 Global Instance Proper_impl1_impl1 T : Proper (Basics.flip impl1 ==> impl1 ==> Basics.impl) (@impl1 T). firstorder idtac. Qed.
@@ -12,6 +20,7 @@ Global Instance Proper_iff1_impl1 T : Proper (Basics.flip impl1 ==> impl1 ==> Ba
 Global Instance Proper_impl1_iff1 T : Proper (iff1 ==> iff1 ==> iff) (@impl1 T). firstorder idtac. Qed.
 Global Instance Proper_ex1_iff1 A B : Proper (pointwise_relation _ iff1 ==> iff1) (@ex1 A B). firstorder idtac. Qed.
 Global Instance Proper_ex1_impl1 A B : Proper (pointwise_relation _ impl1 ==> impl1) (@ex1 A B). firstorder idtac. Qed.
+
 Lemma impl1_ex1_l {A B} p q : impl1 (@ex1 A B p) q <-> (forall x, impl1  (p x) q).
 Proof. firstorder idtac. Qed.
 Lemma impl1_ex1_r {A B} p q x : impl1 p (q x) -> impl1 p (@ex1 A B q).

--- a/bedrock2/src/ListPred.v
+++ b/bedrock2/src/ListPred.v
@@ -1,0 +1,36 @@
+Require Import Coq.Lists.List. Import ListNotations.
+
+Section ListPred.
+  Context {T: Type}.
+
+  Definition one(t: T): list T -> Prop := eq [t].
+
+  Definition concat(P1 P2: list T -> Prop): list T -> Prop :=
+    fun l => exists l1 l2, l = l1 ++ l2 /\ P1 l1 /\ P2 l2.
+
+  Definition choice(P1 P2: list T -> Prop): list T -> Prop :=
+    fun l => P1 l \/ P2 l.
+
+  Inductive kleene(P: list T -> Prop): list T -> Prop :=
+  | kleene_empty:
+      kleene P nil
+  | kleene_step: forall l1 l2,
+      P l1 ->
+      kleene P l2 ->
+      kleene P (l1 ++ l2).
+
+  (* more powerful than regex: *)
+
+  Definition both(P1 P2: list T -> Prop): list T -> Prop :=
+    fun l => P1 l /\ P2 l.
+
+  Definition existsl{A: Type}(P: A -> list T -> Prop): list T -> Prop :=
+    fun l => exists a, P a l.
+
+End ListPred.
+
+Module ListPredNotations.
+  Notation "P ^*" := (kleene P) (at level 50).
+  Infix "+++" := concat (at level 60).
+  Infix "|||" := choice (at level 70).
+End ListPredNotations.


### PR DESCRIPTION
Here's how, according to my current understanding, a squarer program with IO could be specified by abstracting over the kind of IO, and how the IO kind could be instantiated to syscalls or bare-metal MMIO to an ethernet card connected via SPI (inspired by the ethernet driver code you sent me a while ago).
@andres-erbsen does that make sense to you?
