### PR TITLE
Fix build on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ update_all:
 	git submodule update --recursive --remote
 
 REL_PATH_OF_THIS_MAKEFILE:=$(lastword $(MAKEFILE_LIST))
+ABS_ROOT_DIR:=$(abspath $(dir $(REL_PATH_OF_THIS_MAKEFILE)))
 # use cygpath -m because Coq on Windows cannot handle cygwin paths
 ABS_ROOT_DIR:=$(shell cygpath -m '$(ABS_ROOT_DIR)' 2>/dev/null || echo '$(ABS_ROOT_DIR)')
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,8 @@ update_all:
 	git submodule update --recursive --remote
 
 REL_PATH_OF_THIS_MAKEFILE:=$(lastword $(MAKEFILE_LIST))
-ABS_ROOT_DIR:=$(abspath $(dir $(REL_PATH_OF_THIS_MAKEFILE)))
+# use cygpath -m because Coq on Windows cannot handle cygwin paths
+ABS_ROOT_DIR:=$(shell cygpath -m '$(ABS_ROOT_DIR)' 2>/dev/null || echo '$(ABS_ROOT_DIR)')
 
 DEPS_DIR ?= $(ABS_ROOT_DIR)/deps
 export DEPS_DIR

--- a/bedrock2/Makefile
+++ b/bedrock2/Makefile
@@ -3,7 +3,8 @@ default_target: all
 .PHONY: clean force all
 
 # absolute paths so that emacs compile mode knows where to find error
-SRCDIR := $(shell pwd)/src
+# use cygpath -m because Coq on Windows cannot handle cygwin paths
+SRCDIR := $(shell cygpath -m "$$(pwd)" 2>/dev/null || pwd)/src
 
 VS:=$(shell find $(SRCDIR) -type f -name '*.v')
 

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -12,8 +12,9 @@ _CoqProject:
 	printf -- '$(DEPFLAGS_NL)' > _CoqProject
 
 # absolute paths so that emacs compile mode knows where to find error
-SRCDIR := $(shell pwd)/src
-LIBDIR := $(shell pwd)/lib
+# use cygpath -m because Coq on Windows cannot handle cygwin paths
+SRCDIR := $(shell cygpath -m "$$(pwd)" 2>/dev/null || pwd)/src
+LIBDIR := $(shell cygpath -m "$$(pwd)" 2>/dev/null || pwd)/lib
 
 ALL_VS := $(shell find $(SRCDIR) $(LIBDIR) -type f -name '*.v')
 

--- a/processor/Makefile
+++ b/processor/Makefile
@@ -12,7 +12,8 @@ _CoqProject:
 	printf -- '$(DEPFLAGS_NL)' > _CoqProject
 
 # absolute paths so that emacs compile mode knows where to find error
-SRCDIR := $(shell pwd)/src
+# use cygpath -m because Coq on Windows cannot handle cygwin paths
+SRCDIR := $(shell cygpath -m "$$(pwd)" 2>/dev/null || pwd)/src
 ALL_VS := $(shell find $(SRCDIR) -type f -name '*.v')
 
 all: Makefile.coq.all $(ALL_VS)


### PR DESCRIPTION
Coq on Windows generally does not support paths like `/cygdrive/d/Documents/GitHub/bedrock2/deps/coqutil/src/Datatypes/HList.v`.  These are the sorts of paths generated by `pwd` / `find` under cygwin, unless you run the initial path through `cygpath -m` (`-m` for mixed, which makes it use forward slashes).  We pipe stderr to `/dev/null` and fallback to `pwd` on platforms where `cygpath` is not in path (i.e., non-windows platforms).

Note that https://github.com/mit-plv/coqutil/pull/2 and https://github.com/mit-plv/riscv-coq/pull/6 will also need to be merged and the submodules will need to be updated.