### PR TITLE
compatibility with PR #9856

### DIFF
--- a/bedrock2/src/Examples/ArrayLoadStore.v
+++ b/bedrock2/src/Examples/ArrayLoadStore.v
@@ -78,7 +78,7 @@ Proof.
   seprewrite_in (symmetry! @array_cons) H2.
   seprewrite_in (@bytearray_index_merge) H4. {
     pose proof Properties.word.unsigned_range i.
-    rewrite length_firstn_inbounds; (PreOmega.zify; rewrite Znat.Z2Nat.id; bomega).
+    rewrite length_firstn_inbounds; (PreOmega.zify; rewrite ?Znat.Z2Nat.id; bomega).
   }
 
   letexists.

--- a/bedrock2/src/Examples/bsearch.v
+++ b/bedrock2/src/Examples/bsearch.v
@@ -135,7 +135,7 @@ Proof.
         rewrite length_skipn.
         rewrite Z.div_mul by discriminate.
         (* Z and nat ... *)
-        PreOmega.zify; rewrite Z2Nat.id in *; Z.div_mod_to_equations; blia. }
+        PreOmega.zify; rewrite ?Z2Nat.id in *; Z.div_mod_to_equations; blia. }
       { subst v'. subst v. subst x7.
         set (\_ (x1 ^+ (x2 ^- x1) ^>> /_ 4 ^<< /_ 3 ^- x1) / \_ (/_ 8)) as X.
         assert (X < Z.of_nat (Datatypes.length x)). {
@@ -167,7 +167,7 @@ Proof.
         repeat match goal with |- context[word.unsigned ?e] => let H := unsigned.zify_expr e in try rewrite H end.
         rewrite List.firstn_length_le; cycle 1.
         { assert (Datatypes.length x <> 0)%nat by bomega.
-          revert H13. clear. intros. Z.div_mod_to_equations; zify; rewrite Z2Nat.id by blia; blia. }
+          revert H13. clear. intros. Z.div_mod_to_equations; zify; rewrite ?Z2Nat.id by blia; blia. }
         rewrite Z2Nat.id by (clear; Z.div_mod_to_equations; blia).
         clear. Z.div_mod_to_equations. blia. }
       { subst v. subst v'. subst x7.
@@ -177,8 +177,8 @@ Proof.
         repeat match goal with |- context[word.unsigned ?e] => let H := unsigned.zify_expr e in try rewrite H end.
         assert (Datatypes.length x <> 0)%nat by bomega.
         rewrite List.firstn_length_le; cycle 1.
-        { revert H12. clear. intros. Z.div_mod_to_equations; zify; rewrite Z2Nat.id by blia; blia. }
-        revert H12. clear. zify. rewrite Z2Nat.id; (Z.div_mod_to_equations; blia). }
+        { revert H12. clear. intros. Z.div_mod_to_equations; zify; rewrite ?Z2Nat.id by blia; blia. }
+        revert H12. clear. zify. rewrite ?Z2Nat.id; (Z.div_mod_to_equations; blia). }
       subst x8. SeparationLogic.seprewrite_in (symmetry! @array_address_inbounds) H6.
       { rewrite ?Properties.word.word_sub_add_l_same_l, ?Properties.word.word_sub_add_l_same_r.
         destruct x; cbn [Datatypes.length] in *.

--- a/bedrock2/src/Examples/lightbulb.v
+++ b/bedrock2/src/Examples/lightbulb.v
@@ -249,9 +249,9 @@ Proof.
     { replace (word.add p_addr i) with p_addr by (subst i; ring).
       rewrite <- (List.firstn_skipn (Z.to_nat (word.unsigned (word.sub num_bytes i) ) )  _) in H.
       SeparationLogic.seprewrite_in (symmetry! @bytearray_index_merge) H; [|ecancel_assumption].
-      rewrite List.length_firstn_inbounds, Znat.Z2Nat.id; trivial.
+      rewrite List.length_firstn_inbounds, ?Znat.Z2Nat.id; trivial.
       { eapply Properties.word.unsigned_range. }
-      trans_ltu. eapply Znat.Nat2Z.inj_le. rewrite -> Znat.Z2Nat.id.
+      trans_ltu. eapply Znat.Nat2Z.inj_le. rewrite -> ?Znat.Z2Nat.id.
       { rewrite -> H0.
         replace (word.sub num_bytes i) with num_bytes by (subst i; ring).
         rewrite word.unsigned_of_Z in H2. change (word.wrap 1521) with (1521) in H2.
@@ -260,12 +260,12 @@ Proof.
       eapply Properties.word.unsigned_range. }
     { replace (word.sub num_bytes i) with num_bytes by (subst i; ring).
       rewrite -> List.length_firstn_inbounds.
-      { rewrite Znat.Z2Nat.id; trivial; eapply Properties.word.unsigned_range. }
+      { rewrite ?Znat.Z2Nat.id; trivial; eapply Properties.word.unsigned_range. }
       rewrite H0. trans_ltu.
       change (word.unsigned (word.of_Z 1521)) with (1521) in H2.
       pose proof Properties.word.unsigned_range num_bytes.
       PreOmega.zify.
-      rewrite Znat.Z2Nat.id; Lia.lia. }
+      rewrite ?Znat.Z2Nat.id; Lia.lia. }
     { pose proof Properties.word.unsigned_range num_bytes. PreOmega.zify.
       subst i. subst num_bytes. subst num_bytes2.
       replace (word.add (word.add num_bytes1 num_bytes1) (word.add num_bytes1 num_bytes1)) with (word.mul num_bytes1 (word.of_Z 4)) in * by ring.


### PR DESCRIPTION
zify has support for Z.to_nat and therefore a sequence such as zify ; rewrites Z2Nat.id  fails.
This commit inserts a ? to ensure the unconditional success of the rewrite.