### PR TITLE
Makes the BytedumpTest target build on OSX.

### DIFF
--- a/bedrock2/Makefile
+++ b/bedrock2/Makefile
@@ -29,7 +29,8 @@ Makefile.coq.all: force _CoqProject
 	$(COQ_MAKEFILE) $(VS) -o Makefile.coq.all
 
 special/BytedumpTest.out: special/BytedumpTest.v special/BytedumpTest.golden.bin all_coqmakefile
-	coqc -q $(DEPFLAGS) $< | head --bytes -1 > special/BytedumpTest.out.tmp
+	coqc -q $(DEPFLAGS) $< > special/BytedumpTest.out.tmp0
+	head -c $$(($$(wc -c < special/BytedumpTest.out.tmp0 | xargs) - 1)) special/BytedumpTest.out.tmp0 > special/BytedumpTest.out.tmp
 	hexdump < /dev/null && \
 		hexdump -C special/BytedumpTest.golden.bin > special/BytedumpTest.golden.hex && \
 		hexdump -C special/BytedumpTest.out.tmp > special/BytedumpTest.out.hex && \


### PR DESCRIPTION
Turns out OSX's `head` doesn't support negative length parameters.

Tested on OSX, CI will hopefully test if I broke the linux build.