### PR TITLE
Overlay for PR #9918 - refer to the right submodule for Kami

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/mit-plv/coqutil.git
 [submodule "deps/kami"]
 	path = deps/kami
-	url = https://github.com/mit-plv/kami.git
+        url = https://github.com/mattam82/kami.git


### PR DESCRIPTION
Well this is not ideal, I updated my PR on Kami but bedrock2 is not in sync with the branch of Kami. How should we do this?