### PR TITLE
standardize mmio strings to "MMIOREAD" and "MMIOWRITE"

### DIFF
--- a/compiler/src/compilerExamples/FE310Compiler.v
+++ b/compiler/src/compilerExamples/FE310Compiler.v
@@ -127,9 +127,9 @@ Definition main(c: cmd): list byte :=
 Example a: varname := 1.
 Example b: varname := 2.
 Example mmio_adder: cmd :=
-  (cmd.seq (cmd.interact [a] MMInput [expr.literal magicMMIOAddrLit])
-  (cmd.seq (cmd.interact [b] MMInput [expr.literal magicMMIOAddrLit])
-           (cmd.interact [] MMOutput [expr.literal magicMMIOAddrLit;
+  (cmd.seq (cmd.interact [a] "MMIOREAD"%string [expr.literal magicMMIOAddrLit])
+  (cmd.seq (cmd.interact [b] "MMIOREAD"%string [expr.literal magicMMIOAddrLit])
+           (cmd.interact [] "MMIOWRITE"%string [expr.literal magicMMIOAddrLit;
                                         expr.op bopname.add (expr.var a) (expr.var b)]))).
 
 (* Eval vm_compute in compileFunc mmio_adder. *)

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -21,7 +21,6 @@ Require Import riscv.Utility.MkMachineWidth.
 Require Import riscv.Utility.Monads. Import MonadNotations.
 Require Import riscv.Utility.runsToNonDet.
 Require Import coqutil.Datatypes.PropSet.
-Require Import riscv.Utility.MMIOTrace.
 Require Import riscv.Platform.RiscvMachine.
 Require Import riscv.Platform.MetricRiscvMachine.
 Require Import riscv.Spec.MetricPrimitives.

--- a/processor/integration/system.v
+++ b/processor/integration/system.v
@@ -177,7 +177,7 @@ module system(
   always #1 clk = !clk;
   initial begin
     $dumpfile("system.vcd");
-    $dumpvars(1, led, spi_clk, spi_csn, spi_mosi, spi_miso, clk, resetn, rdy_obtain_rq_get, en_obtain_rq_get, mem_rq_addr, mem_rq_data, mem_rq_iswrite, ram_rs_en, ram_read, instant_rs_en, instant_rs, rdy_send_rs_put, spi_tx_buf, spi_rx_buf, spi_tx_rdy);
+    $dumpvars(1, mkTop.proc_m13_lastPc, mkTop.proc_m13_stall, mkTop.WILL_FIRE_RL_proc_m12_execNm, mkTop.WILL_FIRE_RL_proc_m10_modifyPc, mkTop.WILL_FIRE_RL_proc_m12_execBypass, led, spi_clk, spi_csn, spi_mosi, spi_miso, clk, resetn, rdy_obtain_rq_get, en_obtain_rq_get, mem_rq_addr, mem_rq_data, mem_rq_iswrite, ram_rs_en, ram_read, instant_rs_en, instant_rs, rdy_send_rs_put, spi_tx_buf, spi_rx_buf, spi_tx_rdy);
     #90000 $finish();
   end
 `endif

--- a/processor/src/processor/KamiRiscv.v
+++ b/processor/src/processor/KamiRiscv.v
@@ -22,7 +22,6 @@ Require Import riscv.Platform.Run.
 Require Import riscv.Utility.MkMachineWidth.
 Require Import riscv.Utility.Monads. Import MonadNotations.
 Require Import coqutil.Datatypes.PropSet.
-Require Import riscv.Utility.MMIOTrace.
 Require Import riscv.Platform.RiscvMachine.
 Require Import riscv.Platform.MetricRiscvMachine.
 Require Import riscv.Platform.MinimalMMIO.
@@ -92,10 +91,10 @@ Section Equiv.
     word.of_Z (BitOps.signExtend (8 * Z.of_nat n) (LittleEndian.combine n v)).
 
   Definition mmioLoadEvent(m: mem)(addr: word)(n: nat)(v: HList.tuple byte n): LogItem :=
-    ((m, MMInput, [addr]), (m, [signedByteTupleToReg v])).
+    ((m, "MMIOREAD"%string, [addr]), (m, [signedByteTupleToReg v])).
 
   Definition mmioStoreEvent(m: mem)(addr: word)(n: nat)(v: HList.tuple byte n): LogItem :=
-    ((m, MMOutput, [addr; signedByteTupleToReg v]), (m, [])).
+    ((m, "MMIOWRITE"%string, [addr; signedByteTupleToReg v]), (m, [])).
 
   (* common event between riscv-coq and Kami *)
   Inductive Event: Type :=
@@ -105,9 +104,9 @@ Section Equiv.
   (* note: given-away and received memory has to be empty *)
   Inductive events_related: Event -> LogItem -> Prop :=
   | relate_MMInput: forall addr v,
-      events_related (MMInputEvent addr v) ((map.empty, MMInput, [addr]), (map.empty, [v]))
+      events_related (MMInputEvent addr v) ((map.empty, "MMIOREAD"%string, [addr]), (map.empty, [v]))
   | relate_MMOutput: forall addr v,
-      events_related (MMOutputEvent addr v) ((map.empty, MMOutput, [addr; v]), (map.empty, [])).
+      events_related (MMOutputEvent addr v) ((map.empty, "MMIOWRITE"%string, [addr; v]), (map.empty, [])).
 
   Inductive traces_related: list Event -> list LogItem -> Prop :=
   | relate_nil:


### PR DESCRIPTION
untested because the build is [failing](https://gist.github.com/andres-erbsen/0d85ab0dcba161ded69a5808ce906ef6) on my machine