### PR TITLE
ExtSpec of FE310 is now from riscv-coq

### DIFF
--- a/compiler/src/compilerExamples/FE310Compiler.v
+++ b/compiler/src/compilerExamples/FE310Compiler.v
@@ -28,6 +28,7 @@ Require Import riscv.Utility.InstructionCoercions.
 Require Import bedrock2.Byte.
 Require bedrock2.Hexdump.
 Require Import compilerExamples.MMIO.
+Require Import riscv.Platform.FE310ExtSpec.
 Require Import coqutil.Z.HexNotation.
 Require Import compiler.GoFlatToRiscv.
 

--- a/compiler/src/compilerExamples/FE310Compiler.v
+++ b/compiler/src/compilerExamples/FE310Compiler.v
@@ -43,7 +43,6 @@ Existing Instance coqutil.Map.SortedListString.ok.
 Instance mmio_params: MMIO.parameters := { (* everything is inferred automatically *) }.
 
 (* needed because different unfolding levels of implicit arguments *)
-Instance riscv_ext_spec': ExtSpec := processor_mmio.
 Instance MetricMinimalMMIOPrimitivesParams':
   PrimitivesParams (free action result) MetricRiscvMachine :=
   MetricMinimalMMIOPrimitivesParams.
@@ -91,21 +90,21 @@ Proof.
     split; [reflexivity|].
     repeat (destruct_one_match_hyp; try contradiction).
     all: subst.
+    { destruct H1 as (?&?&?&?&?&?); subst.
+      eexists _, _; split; [|split; [|split] ]; eauto. }
     { destruct H1 as (?&?&?&?&?); subst.
-      eexists _, _; split; [|split]; eauto. }
-    { destruct H1 as (?&?&?&?); subst.
-      eexists  _; split; [|split]; eauto. }
+      eexists  _; split; [|split; [|split] ]; eauto. }
   - unfold bedrock2_interact. intros.
     destruct H0; destruct H0.
     split; [reflexivity|].
     repeat (destruct_one_match_hyp; try contradiction).
     all: subst.
+    { destruct H1 as (?&?&?&?&?&?); subst.
+      destruct H as (?&?&?&?&?&?&?); subst.
+      eexists _, _; split; [|split; [|split] ]; eauto. }
     { destruct H1 as (?&?&?&?&?); subst.
       destruct H as (?&?&?&?&?&?); subst.
-      eexists _, _; split; [|split]; eauto. }
-    { destruct H1 as (?&?&?&?); subst.
-      destruct H as (?&?&?&?&?); subst.
-      eexists  _; split; [|split]; eauto. }
+      eexists  _; split; [|split; [|split] ]; eauto. }
     Unshelve.
     all : case shelved_evar_from_other_admit.
 Qed.

--- a/compiler/src/compilerExamples/FibCompiled.v
+++ b/compiler/src/compilerExamples/FibCompiled.v
@@ -17,7 +17,6 @@ Require Import coqutil.Map.SortedList.
 Require Import compiler.ZNameGen.
 Require Import riscv.Utility.InstructionCoercions.
 Require Import riscv.Platform.MetricRiscvMachine.
-Require Import compilerExamples.MMIO.
 Require Import compiler.GoFlatToRiscv.
 Require Import compiler.FlatToRiscvCommon.
 Require Import compiler.SeparationLogic.

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -112,7 +112,6 @@ Section Connect.
     word_ok := @KamiWord.wordWok _ (or_introl eq_refl);
   }.
 
-  (* TODO why is this needed to make the Check below pass? *)
   Goal True.
   epose (_ : PrimitivesParams (MinimalMMIO.free MetricMinimalMMIO.action MetricMinimalMMIO.result)
                               MetricRiscvMachine).

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -34,6 +34,7 @@ Require Import processor.KamiRiscv.
 Require Import bedrock2.Syntax bedrock2.Semantics.
 Require Import compiler.PipelineWithRename.
 Require Import compilerExamples.MMIO.
+Require Import riscv.Platform.FE310ExtSpec.
 Require Import compiler.FlatToRiscvDef.
 Require Import coqutil.Tactics.rdelta.
 Require Import bedrock2.Byte.
@@ -112,7 +113,6 @@ Section Connect.
   }.
 
   (* TODO why is this needed to make the Check below pass? *)
-  Instance processor_mmio': MinimalMMIO.ExtSpec := @processor_mmio mmio_params.
   Goal True.
   epose (_ : PrimitivesParams (MinimalMMIO.free MetricMinimalMMIO.action MetricMinimalMMIO.result)
                               MetricRiscvMachine).


### PR DESCRIPTION
This is along with https://github.com/mit-plv/riscv-coq/pull/23, to move the ExtSpec of FE310 to riscv-coq.
Additionally required to update riscv-coq with the most recent commit point that includes the above pull request.