### PR TITLE
Minimal compatibility fix so that NotationsCustomEntry.v compiles after Coq bugs #9517/#9519/#11331 are fixed by Coq PR #11530

### DIFF
--- a/bedrock2/src/bedrock2/NotationsCustomEntry.v
+++ b/bedrock2/src/bedrock2/NotationsCustomEntry.v
@@ -92,8 +92,7 @@ Notation "'while' e { c }" := (while e c%bedrock_nontail)
   (in custom bedrock_cmd at level 0, no associativity, e custom bedrock_expr, c at level 0,
   format "'[v' 'while'  e  {  '/  ' c '/' } ']'").
 
-(* COQBUG(9517) *)
-Notation "x = ( e )" := (set x e) (in custom bedrock_cmd at level 0, x constr at level 0, e custom bedrock_expr).
+Notation "x = ( e )" := (set x e) (in custom bedrock_cmd at level 0, x custom bedrock_cmd, e custom bedrock_expr).
 (* DRAFT: *)
 Notation "/*skip*/" := skip (in custom bedrock_cmd).
 Notation "store1( a , v )" := (store access_size.one a v)


### PR DESCRIPTION
The point is that in line:
```
Notation "x = ( e )" := (set x e) (in custom bedrock_cmd at level 0, x constr at level 0, e custom bedrock_expr).
```
The reference `x constr at level 0` was wrongly interpreted as `x custom bedrock_expr`.

So that `NotationsCustomEntry.v` compiles, I simulated the old (buggy) behavior:
```
Notation "x = ( e )" := (set x e) (in custom bedrock_cmd at level 0, x custom bedrock_cmd, e custom bedrock_expr).
```
I tried a bit to respect the suspected intent and to instead remove the `constr:(_)` into `_` in line 183 (and following) but the grammar does not factorize correctly the call to `global` and to `constr at level 0`, leading to a failure at line 185 (the parser enters the `x = ( e )` rules and is not able to backtrack to enter instead the `f ( x , y , z )` rule).

Not knowing exactly the purpose of the `x = ( e )` notation, I renounced to investigate how to resolve this lack of factorization.

This PR can be merged as soon as now since its only purpose is to simulate the buggy behavior after coq/coq#11530 is merged. Merging it will permit to merge #11530.

Of course, this does not preclude to later rework the `bedrock_cmd` grammar, taking into account that #9517 is fixed.