### PR TITLE
Remove TODO from mulhuu C representation

### DIFF
--- a/bedrock2/src/bedrock2/BasicCSyntax.v
+++ b/bedrock2/src/bedrock2/BasicCSyntax.v
@@ -15,7 +15,7 @@ Definition to_c_parameters : ToCString.parameters := {|
              | add => e1++"+"++e2
              | sub => e1++"-"++e2
              | mul => e1++"*"++e2
-             | mulhuu => "sizeof(intptr_t) == 4 ? ((uint64_t)"++e1++"*"++e2++")>>32 : ((__uint128_t)"++e1++"*"++e2++")>>64 /* TODO this has not been tested */"
+             | mulhuu => "sizeof(intptr_t) == 4 ? ((uint64_t)"++e1++"*"++e2++")>>32 : ((__uint128_t)"++e1++"*"++e2++")>>64"
              | divu => e1++"/"++e2
              | remu => e1++"%"++e2
              | and => e1++"&"++e2


### PR DESCRIPTION
I tested the translation of mulhuu to C, so I believe the TODO can be removed.

My methodology was to take the [generated bedrock2 code](https://github.com/mit-plv/fiat-crypto/blob/ad5026fb98fec64db2fbe312c131e948ba24607c/fiat-bedrock2/src/curve25519_64.c) in fiat-crypto, which uses the `BasicCSyntax` translation from bedrock2 to C, and plug it into BoringSSL instead of the code from fiat-crypto's C backend. I replaced all curve25519 64-bit field operations except for `to_bytes` and `from_bytes`, which meant a lot of use of `mulhuu`, and the BoringSSL test suite still passed.

Interestingly, I did get test failures for `from_bytes` (and a warning-as-failure for `to_bytes` because of a tautological compare). It's possible that the assertions are too tight, but I think either me or Sam or Andres should look into it further and make sure the C translation is correct when dealing with mixed 64-bit integers and bytes.