### PR TITLE
Add stackalloc to callees tactic

### DIFF
--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -24,7 +24,7 @@ End bindcmd.
 Fixpoint callees (c : Syntax.cmd) : list String.string :=
   match c with
   | cmd.cond _ c1 c2 | cmd.seq c1 c2 => callees c1 ++ callees c2
-  | cmd.while _ c => callees c
+  | cmd.while _ c | cmd.stackalloc _ _ c => callees c
   | cmd.call _ f _ => cons f nil
   | _ => nil
   end.


### PR DESCRIPTION
I was trying out a proof using stack allocation and found that `cmd.stackalloc` is missing from the `callees` tactic, meaning that the goal generated for a function including

```coq
cmd.stackalloc 4 a (cmd.call "foo" [a] ...)
```

ends up without a `spec_of "foo"` instance in scope!