### PR TITLE
feature: expr.inlinetable

### DIFF
--- a/bedrock2/src/bedrock2/Semantics.v
+++ b/bedrock2/src/bedrock2/Semantics.v
@@ -1,7 +1,7 @@
 Require Import coqutil.sanity coqutil.Macros.subst coqutil.Macros.unique coqutil.Byte.
 Require Import coqutil.Datatypes.PrimitivePair coqutil.Datatypes.HList.
 Require Import coqutil.Decidable.
-Require Import bedrock2.Notations bedrock2.Syntax coqutil.Map.Interface.
+Require Import bedrock2.Notations bedrock2.Syntax coqutil.Map.Interface coqutil.Map.OfListWord.
 Require Import BinIntDef coqutil.Word.Interface coqutil.Word.LittleEndian.
 Require Import bedrock2.MetricLogging.
 Require Export bedrock2.Memory.
@@ -107,6 +107,12 @@ Section semantics.
                                            (addMetricLoads 2 mc))
                       | None => None
                       end
+      | expr.inlinetable aSize t index =>
+          'Some (index', mc') <- eval_expr index mc | None;
+          'Some v <- load aSize (map.of_list_word t) index' | None;
+          Some (v, (addMetricInstructions 3
+                   (addMetricLoads 4
+                   (addMetricJumps 1 mc'))))
       | expr.load aSize a =>
           'Some (a', mc') <- eval_expr a mc | None;
           'Some v <- load aSize m a' | None;
@@ -123,6 +129,9 @@ Section semantics.
       match e with
       | expr.literal v => Some (word.of_Z v)
       | expr.var x => map.get l x
+      | expr.inlinetable aSize t index =>
+          'Some index' <- eval_expr_old index | None;
+          load aSize (map.of_list_word t) index'
       | expr.load aSize a =>
           'Some a' <- eval_expr_old a | None;
           load aSize m a'

--- a/bedrock2/src/bedrock2/Syntax.v
+++ b/bedrock2/src/bedrock2/Syntax.v
@@ -17,6 +17,7 @@ Module expr.
   | literal (v: Z)
   | var (x: String.string)
   | load (_ : access_size) (addr:expr)
+  | inlinetable (_ : access_size) (table: list Byte.byte) (index: expr)
   | op (op: bopname) (e1 e2: expr).
 End expr. Notation expr := expr.expr.
 

--- a/bedrock2/src/bedrock2/ToCString.v
+++ b/bedrock2/src/bedrock2/ToCString.v
@@ -58,6 +58,7 @@ Fixpoint c_expr (e : expr) : string :=
   | expr.literal v => c_lit v
   | expr.var x => c_var x
   | expr.load s ea => "_br2_load(" ++ c_expr ea ++ ", " ++ c_size s++ ")"
+  | expr.inlinetable s t index => "TODO_inlinetable"
   | expr.op op e1 e2 => c_bop ("(" ++ c_expr e1 ++ ")") op ("(" ++ c_expr e2 ++ ")")
   end.
 

--- a/bedrock2/src/bedrock2/Variables.v
+++ b/bedrock2/src/bedrock2/Variables.v
@@ -8,6 +8,7 @@ Module expr. Import Syntax.expr.
     | literal v => nil
     | var x => cons x nil
     | load _ ea => vars ea
+    | inlinetable _ _ index => vars index
     | op _ e1 e2 => List.app (vars e1) (vars e2)
     end.
 End expr.

--- a/bedrock2/src/bedrock2/WeakestPrecondition.v
+++ b/bedrock2/src/bedrock2/WeakestPrecondition.v
@@ -1,4 +1,4 @@
-Require Import coqutil.Macros.subst coqutil.Macros.unique bedrock2.Notations coqutil.Map.Interface.
+Require Import coqutil.Macros.subst coqutil.Macros.unique bedrock2.Notations coqutil.Map.Interface coqutil.Map.OfListWord.
 Require Import Coq.ZArith.BinIntDef coqutil.Word.Interface.
 Require Import coqutil.dlet bedrock2.Syntax bedrock2.Semantics.
 
@@ -29,6 +29,9 @@ Section WeakestPrecondition.
       | expr.load s e =>
         rec e (fun a =>
         load s m a post)
+      | expr.inlinetable s t e =>
+        rec e (fun a =>
+        load s (map.of_list_word t) a post)
     end.
     Fixpoint expr e := expr_body expr e.
   End WithMemAndLocals.
@@ -73,7 +76,7 @@ Section WeakestPrecondition.
           anybytes a n mStack -> map.split mCombined m mStack ->
           dlet! l := map.put l x a in
           rec c t mCombined l (fun t' mCombined' l' =>
-          exists m' mStack', 
+          exists m' mStack',
           anybytes a n mStack' /\ map.split mCombined' m' mStack' /\
           post t' m' l')
       | cmd.cond br ct cf =>

--- a/bedrock2/src/bedrock2/WeakestPreconditionProperties.v
+++ b/bedrock2/src/bedrock2/WeakestPreconditionProperties.v
@@ -41,6 +41,7 @@ Section WeakestPrecondition.
     { eapply Proper_literal; eauto. }
     { eapply Proper_get; eauto. }
     { eapply IHa1; eauto; intuition idtac. eapply Proper_load; eauto using Proper_load. }
+    { eapply IHa1; eauto; intuition idtac. eapply Proper_load; eauto using Proper_load. }
   Qed.
 
   Global Instance Proper_list_map {A B} :
@@ -201,6 +202,7 @@ Section WeakestPrecondition.
   Proof.
     ind_on Syntax.expr; t.
     { destruct H. destruct H. eexists. eexists. rewrite H. eauto. }
+    { eapply IHe in H; t. cbv [WeakestPrecondition.load] in H0; t. rewrite H. rewrite H0. eauto. }
     { eapply IHe in H; t. cbv [WeakestPrecondition.load] in H0; t. rewrite H. rewrite H0. eauto. }
     { eapply IHe1 in H; t. eapply IHe2 in H0; t. rewrite H, H0; eauto. }
   Qed.

--- a/compiler/src/compiler/CompilerInvariant.v
+++ b/compiler/src/compiler/CompilerInvariant.v
@@ -76,7 +76,7 @@ Section Pipeline1.
       | |- iff1 (emp ?P) (emp ?Q) => apply (RunInstruction.iff1_emp P Q)
       end.
       split; intros _; try exact I.
-      split; [assumption|reflexivity].
+      auto.
   Qed.
 
   Lemma ptsto_bytes_range: forall bs start pastend m a v,

--- a/compiler/src/compiler/ExprImp.v
+++ b/compiler/src/compiler/ExprImp.v
@@ -90,6 +90,7 @@ Section ExprImp1.
       match e with
       | expr.literal _ => 15
       | expr.load _ e => expr_size e + 1
+      | expr.inlinetable _ t i => (Z.of_nat (length t) + 3) / 4 + expr_size i + 3
       | expr.var _ => 1
       | expr.op op e1 e2 => expr_size e1 + expr_size e2 + 2
       end.
@@ -97,6 +98,10 @@ Section ExprImp1.
     Lemma expr_size_pos: forall exp, expr_size exp > 0.
     Proof.
       induction exp; simpl; try blia.
+      assert (0 <= (Z.of_nat (Datatypes.length table) + 3) / 4). {
+        apply Z.div_pos; blia.
+      }
+      blia.
     Qed.
 
     Definition exprs_size(es: list expr): Z := fold_right (fun e res => res + expr_size e) 0 es.
@@ -220,6 +225,7 @@ Section ExprImp1.
     | expr.literal v => []
     | expr.var x => [x]
     | expr.load nbytes e => allVars_expr_as_list e
+    | expr.inlinetable sz t i => allVars_expr_as_list i
     | expr.op op e1 e2 => (allVars_expr_as_list e1) ++ (allVars_expr_as_list e2)
     end.
 
@@ -245,6 +251,7 @@ Section ExprImp1.
     | expr.literal v => empty_set
     | expr.var x => singleton_set x
     | expr.load nbytes e => allVars_expr e
+    | expr.inlinetable sz t i => allVars_expr i
     | expr.op op e1 e2 => union (allVars_expr e1) (allVars_expr e2)
     end.
 

--- a/compiler/src/compiler/FitsStack.v
+++ b/compiler/src/compiler/FitsStack.v
@@ -19,7 +19,7 @@ Section FitsStack.
   Definition stack_usage_impl(outer_rec: env -> stmt Z -> option (Z*Z))(e: env): stmt Z -> option (Z*Z) :=
     fix inner_rec s :=
       match s with
-      | SLoad _ _ _ _ | SStore _ _ _ _ | SLit _ _
+      | SLoad _ _ _ _ | SStore _ _ _ _ | SInlinetable _ _ _ _ | SLit _ _
       | SOp _ _ _ _ | SSet _ _ | SSkip | SInteract _ _ _ => Some (0,0)
       | SStackalloc x n body =>
         if Z.leb 0 n then

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -188,6 +188,9 @@ Section WithParameters.
   | fits_stack_store: forall M N e sz x y o,
       0 <= M -> 0 <= N ->
       fits_stack M N e (SStore sz x y o)
+  | fits_stack_inlinetable: forall M N e sz x table i,
+      0 <= M -> 0 <= N ->
+      fits_stack M N e (SInlinetable sz x table i)
   | fits_stack_stackalloc: forall M N e x n body,
       0 <= M ->
       0 <= n ->

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -701,6 +701,200 @@ Section FlatToRiscv1.
       eauto using disjoint_putmany_preserves_store_bytes.
   Qed.
 
+  Lemma ptsto_instr_compile4bytes: forall l addr,
+      word.unsigned addr mod 4 = 0 ->
+      iff1 (ptsto_instr iset addr (compile4bytes l))
+           (array ptsto (word.of_Z 1) addr
+                  [nth 0 l Byte.x00; nth 1 l Byte.x00; nth 2 l Byte.x00; nth 3 l Byte.x00]).
+  Proof.
+    intros. unfold compile4bytes, ptsto_instr, truncated_scalar, littleendian. simpl.
+    unfold Encode.encode_Invalid.
+    rewrite bitSlice_all_nonneg. 2: cbv; discriminate. 2: apply (@LittleEndian.combine_bound 4).
+    rewrite LittleEndian.split_combine.
+    unfold ptsto_bytes.
+    simpl.
+    wcancel.
+    cbn [seps].
+    rewrite sep_emp_emp.
+    apply RunInstruction.iff1_emp.
+    split. 1: auto.
+    intros _.
+    unfold valid_InvalidInstruction.
+    split. 2: assumption.
+    right.
+    eexists. split. 2: reflexivity.
+    apply (@LittleEndian.combine_bound 4).
+  Qed.
+
+  Lemma program_compile_byte_list_array: forall instrs table addr,
+      instrs = compile_byte_list table ->
+      word.unsigned addr mod 4 = 0 ->
+      exists padding,
+        iff1 (program iset addr instrs)
+             (array ptsto (word.of_Z 1) addr (table ++ padding)).
+  Proof.
+    induction instrs; intros.
+    - exists []. simpl. repeat (destruct table; try discriminate). reflexivity.
+    - rename a into inst0.
+      destruct table as [|b0 table]. 1: discriminate.
+      destruct table as [|b1 table]. {
+        destruct instrs. 2: discriminate. simpl in *. simp.
+        exists [Byte.x00; Byte.x00; Byte.x00].
+        rewrite ptsto_instr_compile4bytes by assumption. simpl.
+        cancel.
+      }
+      destruct table as [|b2 table]. {
+        destruct instrs. 2: discriminate. simpl in *. simp.
+        exists [Byte.x00; Byte.x00].
+        rewrite ptsto_instr_compile4bytes by assumption. simpl.
+        cancel.
+      }
+      destruct table as [|b3 table]. {
+        destruct instrs. 2: discriminate. simpl in *. simp.
+        exists [Byte.x00].
+        rewrite ptsto_instr_compile4bytes by assumption. simpl.
+        cancel.
+      }
+      simpl in *. simp.
+      specialize (IHinstrs _ (word.add addr (word.of_Z 4)) eq_refl).
+      destruct IHinstrs as [padding IH]. 1: solve_divisibleBy4.
+      exists padding.
+      rewrite IH.
+      rewrite ptsto_instr_compile4bytes by assumption.
+      simpl.
+      wcancel.
+  Qed.
+
+  Lemma array_to_of_list_word_at: forall l addr m,
+      array ptsto (word.of_Z 1) addr l m ->
+      m = OfListWord.map.of_list_word_at addr l.
+  Proof.
+    induction l; intros.
+    - unfold OfListWord.map.of_list_word_at, OfListWord.map.of_list_word. simpl in *.
+      unfold emp, MapKeys.map.map_keys in *. simp. rewrite map.fold_empty. reflexivity.
+    - simpl in *. unfold sep in H. simp.
+      specialize (IHl _ _ Hp2). unfold map.split in *. unfold ptsto in Hp1.
+      subst. simp.
+      apply map.map_ext. intro k.
+      rewrite OfListWord.map.get_of_list_word_at.
+      rewrite map.get_putmany_dec.
+      rewrite OfListWord.map.get_of_list_word_at.
+      rewrite map.get_put_dec.
+      rewrite map.get_empty.
+      unfold map.disjoint in *. rename Hp0p1 into D.
+      specialize (D addr). rewrite map.get_put_same in D. specialize D with (1 := eq_refl).
+      destr (word.eqb addr k).
+      + subst k. ring_simplify (word.sub addr addr). rewrite word.unsigned_of_Z. simpl.
+        destruct_one_match. 2: reflexivity.
+        exfalso. eapply D.
+        rewrite OfListWord.map.get_of_list_word_at. exact E.
+      + replace (BinInt.Z.to_nat (word.unsigned (word.sub k addr))) with
+            (S (BinInt.Z.to_nat (word.unsigned (word.sub k (word.add addr (word.of_Z 1)))))).
+        * simpl. destruct_one_match; reflexivity.
+        * destruct (BinInt.Z.to_nat (word.unsigned (word.sub k addr))) eqn: F.
+          -- exfalso. apply E. apply (f_equal Z.of_nat) in F.
+             rewrite Z2Nat.id in F. 2: {
+               pose proof word.unsigned_range (word.sub k addr). blia.
+             }
+             apply (f_equal word.of_Z) in F.
+             simpl in F. (* PARAMRECORDS *)
+             rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
+             rewrite <- add_0_r at 1. change (Z.of_nat 0) with 0 in F. rewrite <- F.
+             ring.
+          -- f_equal.
+             pose proof word.unsigned_range (word.sub k addr).
+             assert (Z.of_nat (S n) < 2 ^ width) by blia.
+             apply (f_equal Z.of_nat) in F.
+             rewrite Z2Nat.id in F by blia.
+             apply (f_equal word.of_Z) in F.
+             simpl in F. (* PARAMRECORDS *)
+             rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
+             ring_simplify (word.sub k (word.add addr (word.of_Z 1))).
+             rewrite F.
+             replace (Z.of_nat (S n)) with (1 + Z.of_nat n) by blia.
+             match goal with
+             | |- Z.to_nat (word.unsigned ?x) = n => ring_simplify x
+             end.
+             rewrite word.unsigned_of_Z. unfold word.wrap.
+             rewrite Z.mod_small by blia.
+             blia.
+  Qed.
+
+  Lemma program_compile_byte_list: forall table addr,
+      exists Padding,
+        impl1 (program iset addr (compile_byte_list table))
+              (Padding * eq (OfListWord.map.of_list_word_at addr table)).
+  Proof.
+    intros. destruct table as [|b0 bs].
+    - simpl. exists (emp True).
+      unfold OfListWord.map.of_list_word_at, OfListWord.map.of_list_word, MapKeys.map.map_keys.
+      simpl. rewrite map.fold_empty.
+      unfold impl1, sep, emp, map.split, map.disjoint. intros m H. simp.
+      exists map.empty, map.empty. ssplit; auto.
+      + rewrite map.putmany_empty_l. reflexivity.
+      + intros. rewrite map.get_empty in H. discriminate.
+    - destr (Z.eqb (word.unsigned addr mod 4) 0).
+      + destruct (program_compile_byte_list_array (b0 :: bs) addr eq_refl E) as [padding P].
+        exists (array ptsto (word.of_Z 1)
+            (word.add addr (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat (length (b0 :: bs))))) padding).
+        rewrite P.
+        rewrite array_append.
+        rewrite sep_comm.
+        unfold impl1.
+        intros m A.
+        unfold sep, map.split in *. simp. do 2 eexists. ssplit. 1: reflexivity. 1,2: assumption.
+        symmetry. apply array_to_of_list_word_at. assumption.
+      + exists (emp True).
+        intros m C.
+        replace (compile_byte_list (b0 :: bs))
+           with (compile4bytes (b0 :: bs) :: compile_byte_list (tl (tl (tl bs)))) in C. 2: {
+          destruct bs as [|b1 table]. 1: reflexivity.
+          simpl in *.
+          destruct table as [|b2 table]. 1: reflexivity.
+          destruct table as [|b3 table]. 1: reflexivity.
+          reflexivity.
+        }
+        simpl in C.
+        apply invert_ptsto_instr in C. apply proj2 in C. congruence.
+  Qed.
+
+  Lemma shift_load_bytes_in_of_list_word: forall l addr n t index,
+      Memory.load_bytes n (OfListWord.map.of_list_word l) index = Some t ->
+      Memory.load_bytes n (OfListWord.map.of_list_word_at addr l) (word.add addr index) = Some t.
+  Proof.
+    induction n; intros.
+    - cbv in t. destruct t. etransitivity. 2: eassumption. reflexivity.
+    - unfold Memory.load_bytes in *.
+      eapply map.invert_getmany_of_tuple_Some in H. simp.
+      eapply map.build_getmany_of_tuple_Some.
+      + simpl in *.
+        rewrite OfListWord.map.get_of_list_word_at.
+        rewrite OfListWord.map.get_of_list_word in Hp0.
+        etransitivity. 2: exact Hp0. do 3 f_equal. solve_word_eq word_ok.
+      + simpl in *. specialize (IHn _ _ Hp1).
+        etransitivity. 2: exact IHn. do 2 f_equal. solve_word_eq word_ok.
+  Qed.
+
+  Lemma load_from_compile_byte_list: forall sz table index v R m addr,
+    Memory.load sz (OfListWord.map.of_list_word table) index = Some v ->
+    (program iset addr (compile_byte_list table) * R)%sep m ->
+    Memory.load sz m (word.add addr index) = Some v.
+  Proof.
+    intros *. intros L M.
+    destruct (program_compile_byte_list table addr) as [Padding P].
+    pose proof Proper_sep_impl1 as A.
+    unfold Morphisms.Proper, Morphisms.respectful in A.
+    specialize A with (1 := P). specialize (A R R). apply A in M. 2: reflexivity.
+    clear A P.
+    unfold Memory.load, Memory.load_Z in *. simp.
+    eapply shift_load_bytes_in_of_list_word in E0.
+    pose proof @subst_load_bytes_for_eq as P. cbv zeta in P.
+    specialize P with (1 := E0) (2 := M).
+    destruct P as [Q P].
+    erewrite load_bytes_of_sep. 1: reflexivity.
+    wcancel_assumption.
+  Qed.
+
 End FlatToRiscv1.
 
 (* if we have valid_machine for the current machine, and need to prove a

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -504,8 +504,6 @@ Section Proofs.
     (* jump to function *)
     eapply runsToStep. {
       eapply run_Jal; simpl; try solve [sidecondition]; cycle 2.
-      - eapply rearrange_footpr_subset; [eassumption|wwcancel].
-      - wcancel_assumption.
       - solve_divisibleBy4.
       - assumption.
     }
@@ -556,16 +554,9 @@ Section Proofs.
     eapply runsToStep. {
       eapply run_store_word with (rs1 := RegisterNames.sp) (rs2 := RegisterNames.ra);
         try solve [sidecondition | simpl; solve_divisibleBy4].
-        all: simpl.
-      2: {
-        eapply rearrange_footpr_subset; [ eassumption | wwcancel ].
-      }
-      1: {
         simpl.
         rewrite map.get_put_diff by (clear; cbv; congruence).
         rewrite map.get_put_same. reflexivity.
-      }
-      wcancel_assumption.
     }
 
     cbn [getRegs getPc getNextPc getMem getLog getMachine getMetrics].
@@ -1443,6 +1434,23 @@ Section Proofs.
       run1det. run1done.
       eapply preserve_subset_of_xAddrs. 1: assumption.
       ecancel_assumption.
+
+    - idtac "Case compile_stmt_correct/SInlinetable".
+      run1det.
+      assert (map.get (map.put initialL_regs x (program_base + !pos + !4)) i = Some index). {
+        rewrite map.get_put_diff by congruence. unfold map.extends in *. eauto.
+      }
+      run1det.
+      assert (Memory.load sz initialL_mem (program_base + !pos + !4 + index + !0) = Some v). {
+        Set Nested Proofs Allowed. Definition TODO: False. Admitted. case TODO.
+      }
+      run1det.
+      rewrite !map.put_put_same in *.
+      assert (x <> RegisterNames.sp). {
+        unfold valid_FlatImp_var, RegisterNames.sp in *.
+        blia.
+      }
+      run1done.
 
     - idtac "Case compile_stmt_correct/SStackalloc".
       rename H1 into IHexec.

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -1442,7 +1442,9 @@ Section Proofs.
       }
       run1det.
       assert (Memory.load sz initialL_mem (program_base + !pos + !4 + index + !0) = Some v). {
-        Set Nested Proofs Allowed. Definition TODO: False. Admitted. case TODO.
+        rewrite add_0_r.
+        eapply load_from_compile_byte_list. 1: eassumption.
+        wcancel_assumption.
       }
       run1det.
       rewrite !map.put_put_same in *.

--- a/compiler/src/compiler/FlatToRiscvLiterals.v
+++ b/compiler/src/compiler/FlatToRiscvLiterals.v
@@ -157,6 +157,7 @@ Section FlatToRiscvLiterals.
     - unfold compile_lit_64bit, compile_lit_32bit in *.
       remember (signExtend 12 (signExtend 32 (bitSlice v 32 64))) as mid.
       remember (signExtend 32 (signExtend 32 (bitSlice v 32 64))) as hi.
+      Simp.protect_equalities.
       cbv [List.app program array] in P.
       simpl in *. (* if you don't remember enough values, this might take forever *)
       repeat match type of X with
@@ -175,7 +176,7 @@ Section FlatToRiscvLiterals.
       rewrite E0.
       f_equal; [|simpl; try solve_MetricLog].
       f_equal.
-      + rewrite! map.put_put_same. f_equal. subst.
+      + rewrite! map.put_put_same. f_equal. Simp.unprotect_equalities. subst.
         apply word.unsigned_inj.
         assert (width = 64) as W64. {
           clear -E0.

--- a/compiler/src/compiler/FlatToRiscvMetric.v
+++ b/compiler/src/compiler/FlatToRiscvMetric.v
@@ -142,6 +142,38 @@ Section Proofs.
       eapply preserve_subset_of_xAddrs. 1: assumption.
       ecancel_assumption.
 
+    - (* SInlinetable *)
+      run1det.
+      assert (map.get (map.put l x (word.add initialL_pc (word.of_Z 4))) i = Some index). {
+        rewrite map.get_put_diff by congruence. assumption.
+      }
+      run1det.
+      assert (Memory.load sz initialL_mem
+                          (word.add (word.add (word.add initialL_pc (word.of_Z 4)) index) (word.of_Z 0))
+              = Some v). {
+        clear - h H1 H9.
+
+        Set Nested Proofs Allowed.
+
+  Lemma load_from_compile_byte_list: forall sz table index v R m addr,
+    Memory.load sz (OfListWord.map.of_list_word table) index = Some v ->
+    (program iset addr (compile_byte_list table) * R)%sep m ->
+    Memory.load sz m (word.add addr index) = Some v.
+  Proof using.
+    intros *. intros L M.
+    unfold Memory.load, Memory.load_Z in *. simp.
+    erewrite load_bytes_of_sep. 1: reflexivity.
+    unfold Memory.load_bytes in *.
+  Admitted.
+
+        rewrite add_0_r.
+        eapply load_from_compile_byte_list. 1: eassumption.
+        wcancel_assumption.
+      }
+      run1det.
+      rewrite !map.put_put_same in *.
+      run1done.
+
     - (* SStackalloc *)
       assert (valid_register RegisterNames.sp) by (cbv; auto).
       specialize (stackalloc_always_0 x n body t mSmall l mc post). move stackalloc_always_0 at bottom.

--- a/compiler/src/compiler/FlatToRiscvMetric.v
+++ b/compiler/src/compiler/FlatToRiscvMetric.v
@@ -151,21 +151,6 @@ Section Proofs.
       assert (Memory.load sz initialL_mem
                           (word.add (word.add (word.add initialL_pc (word.of_Z 4)) index) (word.of_Z 0))
               = Some v). {
-        clear - h H1 H9.
-
-        Set Nested Proofs Allowed.
-
-  Lemma load_from_compile_byte_list: forall sz table index v R m addr,
-    Memory.load sz (OfListWord.map.of_list_word table) index = Some v ->
-    (program iset addr (compile_byte_list table) * R)%sep m ->
-    Memory.load sz m (word.add addr index) = Some v.
-  Proof using.
-    intros *. intros L M.
-    unfold Memory.load, Memory.load_Z in *. simp.
-    erewrite load_bytes_of_sep. 1: reflexivity.
-    unfold Memory.load_bytes in *.
-  Admitted.
-
         rewrite add_0_r.
         eapply load_from_compile_byte_list. 1: eassumption.
         wcancel_assumption.

--- a/compiler/src/compiler/FlattenExprDef.v
+++ b/compiler/src/compiler/FlattenExprDef.v
@@ -112,6 +112,11 @@ Section FlattenExpr1.
         let '(s1, r1, ngs') := flattenExpr ngs None e in
         let '(x, ngs'') := genFresh_if_needed resVar ngs' in
         (FlatImp.SSeq s1 (FlatImp.SLoad sz x r1 0), x, ngs'')
+    | Syntax.expr.inlinetable sz t index =>
+        let '(r1, ngs') := genFresh ngs in (* by picking r1 fresh, we guarantee r1 <> x *)
+        let '(s1, r1, ngs'') := flattenExpr ngs' (Some r1) index in
+        let '(x, ngs''') := genFresh_if_needed resVar ngs'' in
+        (FlatImp.SSeq s1 (FlatImp.SInlinetable sz x t r1), x, ngs''')
     | Syntax.expr.op op e1 e2 =>
         let '(s1, r1, ngs') := flattenExpr ngs None e1 in
         let '(s2, r2, ngs'') := flattenExpr ngs' None e2 in

--- a/compiler/src/compiler/RunInstruction.v
+++ b/compiler/src/compiler/RunInstruction.v
@@ -350,7 +350,9 @@ Section Run.
   Proof.
     t. rewrite sextend_width_nop; [reflexivity|].
     edestruct @invert_ptsto_instr as (DE & ?); [exact mem_ok|ecancel_assumption|].
-    clear -DE iset_bitwidth_matches. destruct DE as [_ H]. unfold verify_iset in *.
+    clear -DE iset_bitwidth_matches.
+    destruct DE as [DE | DE]. 2: { unfold valid_InvalidInstruction in DE. simp. discriminate. }
+    destruct DE as [_ H]. unfold verify_iset in *.
     rewrite <- iset_bitwidth_matches. unfold bitwidth.
     destruct H as [ H | [ H | [ H | H ] ] ]; subst; reflexivity.
   Qed.

--- a/compiler/src/compiler/Spilling.v
+++ b/compiler/src/compiler/Spilling.v
@@ -262,6 +262,10 @@ Section Spilling.
     | SStore sz x y o =>
       load_arg_reg1 x;; load_arg_reg2 y;;
       SStore sz (arg_reg1 x) (arg_reg2 y) o
+    | SInlinetable sz x t i =>
+      load_arg_reg1 i;;
+      SInlinetable sz (res_reg x) t (arg_reg1 i);;
+      save_res_reg x
     | SStackalloc x n body =>
       SStackalloc (res_reg x) n (save_res_reg x;; spill_stmt body)
     | SLit x n =>
@@ -312,7 +316,7 @@ Section Spilling.
 
   Fixpoint max_var(s: stmt): Z :=
     match s with
-    | SLoad _ x y _ | SStore _ x y _ | SSet x y => Z.max x y
+    | SLoad _ x y _ | SStore _ x y _ | SInlinetable _ x _ y | SSet x y => Z.max x y
     | SStackalloc x n body => Z.max x (max_var body)
     | SLit x _ => x
     | SOp x _ y z => Z.max x (Z.max y z)


### PR DESCRIPTION
`expr.inlinetable sz table index` loads `sz` bytes from the statically computed Gallina byte list `table` at `index`, where `index` is an `expr`. It is implemented by inlining the table into the generated instructions. If the result of `expr.inlinetable sz table index` is to be stored in register `x`, and `index` is stored in register `i`, the following assembly is emitted:
```
jal x (4 + len table)      // jump to the add
table[0:4]                 // data
table[4:8]
...
add x x i                  // compute address to load from
lb/lh/lw/lwu/ld x x 0      // load
```
Note that the flattening phase ensures that `i <> x`, so that we can use `x` as a temporary register.