### PR TITLE
Adapt w.r.t. coq/coq#13563.

### DIFF
--- a/bedrock2/src/bedrock2Examples/FlatConstMem.v
+++ b/bedrock2/src/bedrock2Examples/FlatConstMem.v
@@ -370,12 +370,12 @@ Section WithParameters.
     blia.
   Qed.
 
-  Lemma uncurried_load_four_bytes_of_sep_at bs a R m
+  Lemma uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ length bs = 4%nat) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
   Proof. eapply load_four_bytes_of_sep_at; eapply H. Qed.
 
-  Lemma Z_uncurried_load_four_bytes_of_sep_at bs a R m
+  Lemma Z_uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ Z.of_nat (length bs) = 4) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
   Proof. eapply load_four_bytes_of_sep_at; try eapply H; blia. Qed.

--- a/compiler/src/compiler/PipelineWithRename.v
+++ b/compiler/src/compiler/PipelineWithRename.v
@@ -326,7 +326,7 @@ Section Pipeline1.
 
   Local Definition FlatImp__word_eq : FlatImp.word -> FlatImp.word -> bool := word.eqb.
   Local Instance  EqDecider_FlatImp__word_eq : EqDecider FlatImp__word_eq.
-  Proof. eapply word.eqb_spec. Unshelve. exact word_ok. Qed.
+  Proof. eapply word.eqb_spec. Unshelve. all: exact word_ok. Qed.
 
   Lemma mem_available_to_exists: forall start pastend m P,
       (mem_available start pastend * P)%sep m ->


### PR DESCRIPTION
For some unclear but not unexpected reason, type inference behaves slightly differently in coq/coq#13563. This leads to the inference of a type that confuses syntactic matching performed by the Ltac machinery in one file. This PR simply annotates the expected type and is backwards compatible.