### PR TITLE
in Scalars.v, remove word16/word32 instances

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -14,9 +14,8 @@ jobs:
     strategy:
       matrix:
         env:
-        - { COQ_VERSION: "8.13.0", COQ_PACKAGE: "coq-8.13.0 libcoq-8.13.0-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
+        - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq libcoq-ocaml-dev"              , PPA: "ppa:jgross-h/coq-master-daily" }
-      fail-fast: false
 
     env: ${{ matrix.env }}
 

--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -14,8 +14,9 @@ jobs:
     strategy:
       matrix:
         env:
-        - { COQ_VERSION: "8.12.2", COQ_PACKAGE: "coq-8.12.2 libcoq-8.12.2-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
+        - { COQ_VERSION: "8.13.0", COQ_PACKAGE: "coq-8.13.0 libcoq-8.13.0-ocaml-dev", PPA: "ppa:jgross-h/many-coq-versions-ocaml-4-05" }
         - { COQ_VERSION: "master", COQ_PACKAGE: "coq libcoq-ocaml-dev"              , PPA: "ppa:jgross-h/coq-master-daily" }
+      fail-fast: false
 
     env: ${{ matrix.env }}
 

--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -232,18 +232,26 @@ Ltac straightline :=
     let x := rdelta x in is_evar x; change (x=y); exact eq_refl
   | |- ?x = ?y =>
     let x := rdelta x in let y := rdelta y in constr_eq x y; exact eq_refl
-  | |- @store _ Syntax.access_size.one _ _ _ _ =>  eapply Scalars.store_one_of_sep; [solve[ecancel_assumption]|]
-  | |- @store _ Syntax.access_size.two _ _ _ _ =>  eapply Scalars.store_two_of_sep; [solve[ecancel_assumption]|]
-  | |- @store _ Syntax.access_size.four _ _ _ _ =>  eapply Scalars.store_four_of_sep; [solve[ecancel_assumption]|]
-  | |- @store _ Syntax.access_size.word _ _ _ _ =>  eapply Scalars.store_word_of_sep; [solve[ecancel_assumption]|]
+  | |- @store _ Syntax.access_size.one _ _ _ _ =>
+    eapply Scalars.store_one_of_sep; [solve[ecancel_assumption]|]
+  | |- @store _ Syntax.access_size.two _ _ _ _ =>
+    eapply Scalars.store_two_of_sep; [solve[ecancel_assumption]|]
+  | |- @store _ Syntax.access_size.four _ _ _ _ =>
+    eapply Scalars.store_four_of_sep_32bit; [reflexivity|solve[ecancel_assumption]|]
+  | |- @store _ Syntax.access_size.four _ _ _ _ =>
+    eapply Scalars.store_four_of_sep; [solve[ecancel_assumption]|]
+  | |- @store _ Syntax.access_size.word _ _ _ _ =>
+    eapply Scalars.store_word_of_sep; [solve[ecancel_assumption]|]
   | |- bedrock2.Memory.load Syntax.access_size.one ?m ?a = Some ?ev =>
     try subst ev; refine (@Scalars.load_one_of_sep _ _ _ _ _ _ _ _ _ _); ecancel_assumption
   | |- @bedrock2.Memory.load _ ?word ?mem Syntax.access_size.two ?m ?a = Some ?ev =>
-    try subst ev; refine (@Scalars.load_two_of_sep  _ word _ _ _ _ mem _ _ _ _ _); ecancel_assumption
+    try subst ev; refine (@Scalars.load_two_of_sep _ word _ mem _ a _ _ m _); ecancel_assumption
   | |- @bedrock2.Memory.load _ ?word ?mem Syntax.access_size.four ?m ?a = Some ?ev =>
-    try subst ev; refine (@Scalars.load_four_of_sep _ word _ _ _ _ mem _ _ _ _ _); ecancel_assumption
-  | |- bedrock2.Memory.load Syntax.access_size.word ?m ?a = Some ?ev =>
-    try subst ev; refine (@Scalars.load_word_of_sep _ _ _ _ _ _ _ _ _ _); ecancel_assumption
+    try subst ev; refine (@Scalars.load_four_of_sep_32bit _ word _ mem _ eq_refl a _ _ m _); ecancel_assumption
+  | |- @bedrock2.Memory.load _ ?word ?mem Syntax.access_size.four ?m ?a = Some ?ev =>
+    try subst ev; refine (@Scalars.load_four_of_sep _ word _ mem _ a _ _ m _); ecancel_assumption
+  | |- @bedrock2.Memory.load _ ?word ?mem Syntax.access_size.word ?m ?a = Some ?ev =>
+    try subst ev; refine (@Scalars.load_word_of_sep _ word _ mem _ a _ _ m _); ecancel_assumption
   | |- exists l', Interface.map.of_list_zip ?ks ?vs = Some l' /\ _ =>
     letexists; split; [exact eq_refl|] (* TODO: less unification here? *)
   | |- exists l', Interface.map.putmany_of_list_zip ?ks ?vs ?l = Some l' /\ _ =>

--- a/bedrock2/src/bedrock2/Scalars.v
+++ b/bedrock2/src/bedrock2/Scalars.v
@@ -106,8 +106,8 @@ Section Scalars.
     destruct (Z.ltb_spec0 i 32); cbn [andb]; trivial; [].
     destruct (Z.testbit (word.unsigned value) i); cbn [andb]; trivial; [].
     cbn.
-    destruct (Z.leb_spec0 0 i); try blia. cbn [andb].
-    eapply Z.ltb_lt. blia.
+    destruct (Z.leb_spec0 0 i); try blia; cbn [andb];
+    eapply Z.ltb_lt; blia.
   Qed.
 
   Lemma load_four_of_sep_32bit(W32: width = 32) addr value R m

--- a/bedrock2/src/bedrock2/Scalars.v
+++ b/bedrock2/src/bedrock2/Scalars.v
@@ -13,8 +13,6 @@ Import HList List.
 
 Section Scalars.
   Context {width : Z} {word : Word.Interface.word width} {word_ok : word.ok word}.
-  Context {word16 : Word.Interface.word 16} {word16_ok : word.ok word16}.
-  Context {word32 : Word.Interface.word 32} {word32_ok : word.ok word32}.
 
   Context {mem : map.map word byte} {mem_ok : map.ok mem}.
 
@@ -24,22 +22,25 @@ Section Scalars.
   Definition truncated_scalar sz addr (value:Z) : mem -> Prop :=
     littleendian (bytes_per (width:=width) sz) addr value.
 
+  Definition truncated_word sz addr (value: word) : mem -> Prop :=
+    truncated_scalar sz addr (word.unsigned value).
+
   Notation scalar8 := ptsto (only parsing).
 
-  Definition scalar16 addr (value: word16) : mem -> Prop :=
-    truncated_scalar Syntax.access_size.two addr (word.unsigned value).
+  Definition scalar16 := truncated_word Syntax.access_size.two.
+  Definition scalar32 := truncated_word Syntax.access_size.four.
+  Definition scalar := truncated_word Syntax.access_size.word.
 
-  Definition scalar32 addr (value: word32) : mem -> Prop :=
-    truncated_scalar Syntax.access_size.four addr (word.unsigned value).
+  Definition truncate_Z n value := Z.land value (Z.ones (Z.of_nat n * 8)).
 
-  Definition scalar addr (value: word) : mem -> Prop :=
-    truncated_scalar Syntax.access_size.word addr (word.unsigned value).
+  Definition truncate_word(sz: Syntax.access_size)(w: word): word :=
+    word.of_Z (truncate_Z (bytes_per (width := width) sz) (word.unsigned w)).
 
   Lemma load_Z_of_sep sz addr (value: Z) R m
     (Hsep : sep (truncated_scalar sz addr value) R m)
-    : Memory.load_Z sz m addr = Some (Z.land value (Z.ones (Z.of_nat (bytes_per (width:=width) sz)*8))).
+    : Memory.load_Z sz m addr = Some (truncate_Z (bytes_per (width:=width) sz) value).
   Proof.
-    cbv [load scalar littleendian load_Z] in *.
+    cbv [truncate_Z load scalar littleendian load_Z] in *.
     erewrite load_bytes_of_sep by exact Hsep; apply f_equal.
     rewrite LittleEndian.combine_split.
     set (x := (Z.of_nat (bytes_per sz) * 8)%Z).
@@ -54,13 +55,76 @@ Section Scalars.
     : exists m1, Memory.store_Z sz m addr value = Some m1 /\ post m1.
   Proof. eapply store_bytes_of_sep; [eapply Hsep|eapply Hpost]. Qed.
 
+  Lemma load_of_sep sz addr (value: word) R m
+    (Hsep : sep (truncated_word sz addr value) R m)
+    : Memory.load sz m addr = Some (truncate_word sz value).
+  Proof.
+    cbv [load truncate_word truncated_word] in *.
+    erewrite load_Z_of_sep; eauto.
+  Qed.
+
+  Lemma store_of_sep sz addr (oldvalue value: word) R m (post:_->Prop)
+    (Hsep : sep (truncated_word sz addr oldvalue) R m)
+    (Hpost : forall m, sep (truncated_word sz addr value) R m -> post m)
+    : exists m1, Memory.store sz m addr value = Some m1 /\ post m1.
+  Proof.
+    cbv [store truncate_word truncated_word] in *.
+    eapply store_Z_of_sep; eauto.
+  Qed.
+
+  Lemma load_one_of_sep addr value R m
+    (Hsep : sep (scalar8 addr value) R m)
+    : Memory.load Syntax.access_size.one m addr = Some (word.of_Z (byte.unsigned value)).
+  Proof.
+    cbv [load load_Z load_bytes bytes_per footprint tuple.unfoldn map.getmany_of_tuple tuple.option_all tuple.map].
+    erewrite get_sep by exact Hsep; repeat f_equal.
+    cbv [LittleEndian.combine PrimitivePair.pair._1].
+    eapply Z.lor_0_r.
+  Qed.
+
+  Lemma load_two_of_sep addr value R m
+    (Hsep : sep (scalar16 addr value) R m)
+    : Memory.load Syntax.access_size.two m addr = Some (truncate_word Syntax.access_size.two value).
+  Proof. eapply load_of_sep. exact Hsep. Qed.
+
+  Lemma load_four_of_sep addr value R m
+    (Hsep : sep (scalar32 addr value) R m)
+    : Memory.load Syntax.access_size.four m addr = Some (truncate_word Syntax.access_size.four value).
+  Proof. eapply load_of_sep. exact Hsep. Qed.
+
+  Lemma truncate_word_nop_32bit(W32: width = 32)(value: word):
+    truncate_word Syntax.access_size.four value = value.
+  Proof.
+    cbv [truncate_word truncate_Z bytes_per bytes_per_word].
+    eapply Properties.word.unsigned_inj.
+    rewrite !word.unsigned_of_Z.
+    rewrite <-Properties.word.wrap_unsigned at 2.
+    eapply Z.bits_inj'; intros i Hi.
+    rewrite W32 at 4.
+    repeat ((rewrite ?bitblast.Z.testbit_mod_pow2, ?bitblast.Z.testbit_ones, ?Z.lor_spec, ?Z.shiftl_spec, ?Z.shiftr_spec, ?Z.land_spec by blia) || unfold word.wrap).
+    rewrite W32 at 1.
+    destruct (Z.ltb_spec0 i 32); cbn [andb]; trivial; [].
+    destruct (Z.testbit (word.unsigned value) i); cbn [andb]; trivial; [].
+    cbn.
+    destruct (Z.leb_spec0 0 i); try blia; cbn [andb];
+    eapply Z.ltb_lt;
+    rewrite Z2Nat.id; Z.div_mod_to_equations; Lia.nia.
+  Qed.
+
+  Lemma load_four_of_sep_32bit(W32: width = 32) addr value R m
+    (Hsep : sep (scalar32 addr value) R m)
+    : Memory.load Syntax.access_size.four m addr = Some value.
+  Proof.
+    eapply load_of_sep in Hsep. rewrite Hsep. f_equal. apply truncate_word_nop_32bit. assumption.
+  Qed.
+
   Lemma load_word_of_sep addr value R m
     (Hsep : sep (scalar addr value) R m)
     : Memory.load Syntax.access_size.word m addr = Some value.
   Proof.
     cbv [load].
     erewrite load_Z_of_sep by exact Hsep; f_equal.
-    cbv [bytes_per bytes_per_word].
+    cbv [truncate_Z bytes_per bytes_per_word].
     eapply Properties.word.unsigned_inj.
     rewrite !word.unsigned_of_Z.
     rewrite <-Properties.word.wrap_unsigned at 2.
@@ -74,41 +138,6 @@ Section Scalars.
     rewrite Z2Nat.id; Z.div_mod_to_equations; Lia.nia.
   Qed.
 
-  Lemma load_one_of_sep addr value R m
-    (Hsep : sep (scalar8 addr value) R m)
-    : Memory.load Syntax.access_size.one m addr = Some (word.of_Z (byte.unsigned value)).
-  Proof.
-    cbv [load load_Z load_bytes bytes_per footprint tuple.unfoldn map.getmany_of_tuple tuple.option_all tuple.map].
-    erewrite get_sep by exact Hsep; repeat f_equal.
-    cbv [LittleEndian.combine PrimitivePair.pair._1].
-    eapply Z.lor_0_r.
-  Qed.
-
-  (*essentially duplicates of the previous lemma...*)
-  Lemma load_two_of_sep addr value R m
-    (Hsep : sep (scalar16 addr value) R m)
-    : Memory.load Syntax.access_size.two m addr = Some (word.of_Z (word.unsigned value)).
-  Proof.
-    cbv [load].
-    erewrite load_Z_of_sep by exact Hsep; f_equal.
-    cbv [bytes_per].
-    rewrite Z.land_ones; [| blia].
-    rewrite Properties.word.wrap_unsigned.
-    reflexivity.
-  Qed.
-
-  Lemma load_four_of_sep addr value R m
-    (Hsep : sep (scalar32 addr value) R m)
-    : Memory.load Syntax.access_size.four m addr = Some (word.of_Z (word.unsigned value)).
-  Proof.
-    cbv [load].
-    erewrite load_Z_of_sep by exact Hsep; f_equal.
-    cbv [bytes_per].
-    rewrite Z.land_ones; [| blia].
-    rewrite Properties.word.wrap_unsigned.
-    reflexivity.
-  Qed.
-
   Lemma store_one_of_sep addr (oldvalue : byte) (value : word) R m (post:_->Prop)
     (Hsep : sep (scalar8 addr oldvalue) R m)
     (Hpost : forall m, sep (scalar8 addr (byte.of_Z (word.unsigned value))) R m -> post m)
@@ -119,61 +148,70 @@ Section Scalars.
     intros; eapply Hpost; ecancel_assumption.
   Qed.
 
-  Local Ltac remove_wrap x :=
-    match x with
-    | Z.shiftr ?x' ?n =>
-      let x'' := remove_wrap x' in
-      constr:(Z.shiftr x'' n)
-    | word.wrap ?v =>
-      constr:(v)
-    end.
-
-  Local Ltac word_bitblast :=
-    apply word.unsigned_inj;
-    rewrite !word.unsigned_of_Z;
-    cbv [word.wrap];
-    Z.bitblast.
-
   Local Ltac byte_bitblast :=
     apply byte.unsigned_inj;
-    rewrite !byte.unsigned_of_Z;
-    cbv [byte.wrap word.wrap];
+    rewrite ?byte.unsigned_of_Z; cbv [byte.wrap];
+    rewrite ?word.unsigned_of_Z; cbv [word.wrap];
     Z.bitblast.
 
-  Lemma store_two_of_sep addr (oldvalue : word16) (value : word) R m (post:_->Prop)
+  Lemma shrink_upper_bound: forall x b1 b2,
+      0 <= x < b1 ->
+      b1 <= b2 ->
+      0 <= x < b2.
+  Proof. blia. Qed.
+
+  Lemma store_two_of_sep addr (oldvalue : word) (value : word) R m (post:_->Prop)
     (Hsep : sep (scalar16 addr oldvalue) R m)
-    (Hpost : forall m, sep (scalar16 addr (word.of_Z (word.unsigned value))) R m -> post m)
+    (Hpost : forall m, sep (scalar16 addr (truncate_word Syntax.access_size.two value)) R m -> post m)
     : exists m1, Memory.store Syntax.access_size.two m addr value = Some m1 /\ post m1.
   Proof.
-    cbv [scalar16 truncated_scalar littleendian ptsto_bytes bytes_per tuple.to_list LittleEndian.split PrimitivePair.pair._1 PrimitivePair.pair._2 array] in Hsep, Hpost.
+    cbv [scalar16 truncate_Z truncated_word truncate_word truncated_scalar littleendian ptsto_bytes bytes_per tuple.to_list LittleEndian.split PrimitivePair.pair._1 PrimitivePair.pair._2 array] in Hsep, Hpost.
     eapply (store_bytes_of_sep _ 2 (PrimitivePair.pair.mk _ (PrimitivePair.pair.mk _ tt))); cbn; [ecancel_assumption|].
     cbv [LittleEndian.split].
     intros; eapply Hpost.
-    rewrite word.unsigned_of_Z.
-    repeat match goal with
-           | [ |- context[@byte.of_Z ?x] ] =>
-             let x' := remove_wrap x in
-             replace (@byte.of_Z x) with (@byte.of_Z x') by byte_bitblast
-           end.
-    ecancel_assumption.
+    assert (word.unsigned value = word.unsigned value mod 2 ^ width) as E. {
+      symmetry. apply Z.mod_small. apply word.unsigned_range.
+    }
+    rewrite E in *.
+    pose proof word.width_pos.
+    use_sep_assumption.
+    cancel.
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    reflexivity.
   Qed.
 
-  Lemma store_four_of_sep addr (oldvalue : word32) (value : word) R m (post:_->Prop)
+  Lemma store_four_of_sep addr (oldvalue : word) (value : word) R m (post:_->Prop)
     (Hsep : sep (scalar32 addr oldvalue) R m)
-    (Hpost : forall m, sep (scalar32 addr (word.of_Z (word.unsigned value))) R m -> post m)
+    (Hpost : forall m, sep (scalar32 addr (truncate_word Syntax.access_size.four value)) R m -> post m)
     : exists m1, Memory.store Syntax.access_size.four m addr value = Some m1 /\ post m1.
   Proof.
-    cbv [scalar32 truncated_scalar littleendian ptsto_bytes bytes_per tuple.to_list LittleEndian.split PrimitivePair.pair._1 PrimitivePair.pair._2 array] in Hsep, Hpost.
+    cbv [scalar32 truncate_Z truncated_word truncate_word truncated_scalar littleendian ptsto_bytes bytes_per tuple.to_list LittleEndian.split PrimitivePair.pair._1 PrimitivePair.pair._2 array] in Hsep, Hpost.
     eapply (store_bytes_of_sep _ 4 (PrimitivePair.pair.mk _ (PrimitivePair.pair.mk _ (PrimitivePair.pair.mk _ (PrimitivePair.pair.mk _ tt))))); cbn; [ecancel_assumption|].
     cbv [LittleEndian.split].
     intros; eapply Hpost.
     rewrite word.unsigned_of_Z.
-    repeat match goal with
-           | [ |- context[@byte.of_Z ?x] ] =>
-             let x' := remove_wrap x in
-             replace (@byte.of_Z x) with (@byte.of_Z x') by byte_bitblast
-           end.
-    ecancel_assumption.
+    assert (word.unsigned value = word.unsigned value mod 2 ^ width) as E. {
+      symmetry. apply Z.mod_small. apply word.unsigned_range.
+    }
+    rewrite E in *.
+    pose proof word.width_pos.
+    use_sep_assumption.
+    cancel.
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    cancel_seps_at_indices 0%nat 0%nat; [f_equal; byte_bitblast|].
+    reflexivity.
+  Qed.
+
+  Lemma store_four_of_sep_32bit(W32: width = 32) addr (oldvalue : word) (value : word) R m (post:_->Prop)
+    (Hsep : sep (scalar32 addr oldvalue) R m)
+    (Hpost : forall m, sep (scalar32 addr value) R m -> post m)
+    : exists m1, Memory.store Syntax.access_size.four m addr value = Some m1 /\ post m1.
+  Proof.
+    eapply store_four_of_sep. 1: exact Hsep. intros. eapply Hpost.
+    rewrite truncate_word_nop_32bit in H; assumption.
   Qed.
 
   Lemma store_word_of_sep addr (oldvalue value: word) R m (post:_->Prop)
@@ -182,19 +220,24 @@ Section Scalars.
     : exists m1, Memory.store Syntax.access_size.word m addr value = Some m1 /\ post m1.
   Proof. eapply store_bytes_of_sep; [eapply Hsep|eapply Hpost]. Qed.
 
+  Context (width_lower_bound: 32 <= width).
+
   Lemma scalar16_of_bytes a l (H : List.length l = 2%nat) :
     Lift1Prop.iff1 (array ptsto (word.of_Z 1) a l)
                    (scalar16 a (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list l)))).
   Proof.
     do 2 (destruct l as [|?x l]; [discriminate|]). destruct l; [|discriminate].
-    cbv [scalar16 truncated_scalar littleendian ptsto_bytes.ptsto_bytes].
+    cbv [scalar16 truncated_word truncated_scalar littleendian ptsto_bytes.ptsto_bytes].
     eapply Morphisms.eq_subrelation; [exact _|].
     f_equal.
     rewrite word.unsigned_of_Z. cbv [word.wrap]; rewrite Z.mod_small.
     { erewrite LittleEndian.split_combine; exact eq_refl. }
     erewrite <-(LittleEndian.split_combine _ (HList.tuple.of_list (x :: x0 :: nil)%list)).
     erewrite LittleEndian.combine_split.
-    eapply Z.mod_pos_bound; reflexivity.
+    cbn -[tuple.of_list Z.pow].
+    eapply shrink_upper_bound.
+    - eapply Z.mod_pos_bound; reflexivity.
+    - eapply Z.pow_le_mono_r; blia.
   Qed.
 
   (*essentially duplicates of the previous lemma...*)
@@ -203,21 +246,24 @@ Section Scalars.
                    (scalar32 a (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list l)))).
   Proof.
     do 4 (destruct l as [|?x l]; [discriminate|]). destruct l; [|discriminate].
-    cbv [scalar32 truncated_scalar littleendian ptsto_bytes.ptsto_bytes].
+    cbv [scalar32 truncated_word truncated_scalar littleendian ptsto_bytes.ptsto_bytes].
     eapply Morphisms.eq_subrelation; [exact _|].
     f_equal.
     rewrite word.unsigned_of_Z. cbv [word.wrap]; rewrite Z.mod_small.
     { erewrite LittleEndian.split_combine; exact eq_refl. }
     erewrite <-(LittleEndian.split_combine _ (HList.tuple.of_list (x :: x0 :: x1 :: x2 :: nil)%list)).
     erewrite LittleEndian.combine_split.
-    eapply Z.mod_pos_bound; reflexivity.
+    cbn -[tuple.of_list Z.pow].
+    eapply shrink_upper_bound.
+    - eapply Z.mod_pos_bound; reflexivity.
+    - eapply Z.pow_le_mono_r; blia.
   Qed.
 
   Lemma scalar_of_bytes a l (H : width = 8 * Z.of_nat (length l)) :
     Lift1Prop.iff1 (array ptsto (word.of_Z 1) a l)
                    (scalar a (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list l)))).
   Proof.
-    cbv [scalar truncated_scalar littleendian ptsto_bytes]. subst width.
+    cbv [scalar truncated_word truncated_scalar littleendian ptsto_bytes]. subst width.
     replace (bytes_per Syntax.access_size.word) with (length l). 2: {
       unfold bytes_per, bytes_per_word. clear.
       Z.div_mod_to_equations. blia.
@@ -228,7 +274,6 @@ Section Scalars.
     apply LittleEndian.combine_bound.
   Qed.
 
-  Context (Hw : 2 <= width).
   Local Infix "$+" := map.putmany (at level 70).
   Local Notation "xs $@ a" := (map.of_list_word_at a xs) (at level 10, format "xs $@ a").
   Local Infix "*" := sep : type_scope.
@@ -238,16 +283,24 @@ Section Scalars.
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
   Proof.
     seprewrite_in (symmetry! (array1_iff_eq_of_list_word_at(map:=mem))) Hsep.
-    { rewrite Hl. etransitivity. 2:eapply Z.pow_le_mono_r; try eassumption. 2:blia. reflexivity. }
+    { rewrite Hl. etransitivity. 2:eapply Z.pow_le_mono_r; try eassumption. all:blia. }
     unshelve seprewrite_in open_constr:(Scalars.scalar32_of_bytes _ _ _) Hsep; shelve_unifiable; trivial.
     erewrite @Scalars.load_four_of_sep; shelve_unifiable; try exact _; eauto.
     f_equal.
+    unfold truncate_word, truncate_Z.
     f_equal.
     rewrite word.unsigned_of_Z.
-    cbv [word.wrap]; rewrite Z.mod_small; trivial.
-    pose proof LittleEndian.combine_bound (HList.tuple.of_list bs).
-    rewrite Hl in H at 3.
-    blia.
+    rewrite Z.land_ones by blia.
+    cbv [word.wrap]. simpl (Z.of_nat _ * _)%Z.
+    rewrite (Z.mod_small (LittleEndian.combine (length bs) (tuple.of_list bs)) (2 ^ width)). 2: {
+      eapply shrink_upper_bound.
+      - eapply LittleEndian.combine_bound.
+      - eapply Z.pow_le_mono_r; blia.
+    }
+    apply Z.mod_small.
+    eapply shrink_upper_bound.
+    - eapply LittleEndian.combine_bound.
+    - rewrite Hl. reflexivity.
   Qed.
 
   Lemma uncurried_load_four_bytes_of_sep_at bs a R (m : mem)

--- a/bedrock2/src/bedrock2/Scalars.v
+++ b/bedrock2/src/bedrock2/Scalars.v
@@ -106,9 +106,8 @@ Section Scalars.
     destruct (Z.ltb_spec0 i 32); cbn [andb]; trivial; [].
     destruct (Z.testbit (word.unsigned value) i); cbn [andb]; trivial; [].
     cbn.
-    destruct (Z.leb_spec0 0 i); try blia; cbn [andb];
-    eapply Z.ltb_lt;
-    rewrite Z2Nat.id; Z.div_mod_to_equations; Lia.nia.
+    destruct (Z.leb_spec0 0 i); try blia. cbn [andb].
+    eapply Z.ltb_lt. blia.
   Qed.
 
   Lemma load_four_of_sep_32bit(W32: width = 32) addr value R m

--- a/bedrock2/src/bedrock2Examples/FlatConstMem.v
+++ b/bedrock2/src/bedrock2Examples/FlatConstMem.v
@@ -355,30 +355,18 @@ Section WithParameters.
   Lemma load_four_bytes_of_sep_at bs a R m (Hsep: (eq(bs$@a)*R) m) (Hl : length bs = 4%nat) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
   Proof.
-    seprewrite_in (eq_of_list_word_iff_array1) Hsep.
-    { change_with_Z_literal width; blia. }
-    seprewrite_in open_constr:(Scalars.scalar32_of_bytes _ _ _) Hsep.
-    erewrite @Scalars.load_four_of_sep; shelve_unifiable; try exact _; eauto.
-    Unshelve. (* where does this evar come from? *)
-    2: eauto.
-    f_equal.
-    f_equal.
-    rewrite word.unsigned_of_Z.
-    cbv [word.wrap]; rewrite Z.mod_small; trivial.
-    pose proof LittleEndian.combine_bound (HList.tuple.of_list bs).
-    rewrite Hl in H at 3.
-    blia.
+    eapply Scalars.load_four_bytes_of_sep_at; try eassumption. reflexivity.
   Qed.
 
   Lemma uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ length bs = 4%nat) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
-  Proof. eapply load_four_bytes_of_sep_at; eapply H. Qed.
+  Proof. eapply Scalars.uncurried_load_four_bytes_of_sep_at; try eassumption. reflexivity. Qed.
 
   Lemma Z_uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ Z.of_nat (length bs) = 4) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
-  Proof. eapply load_four_bytes_of_sep_at; try eapply H; blia. Qed.
+  Proof. eapply Scalars.Z_uncurried_load_four_bytes_of_sep_at; try eassumption. reflexivity. Qed.
 
   (*
   Lemma store_four_of_sep addr (oldvalue : word32) (value : word) R m (post:_->Prop)
@@ -417,7 +405,7 @@ Section WithParameters.
            | H: context [?e] |- _ => is_evar e; set e in *
            end.
   Ltac subst_evars :=
-    repeat match goal with 
+    repeat match goal with
     x := ?e |- _ => is_evar e; subst x
            end.
 

--- a/bedrock2/src/bedrock2Examples/LAN9250.v
+++ b/bedrock2/src/bedrock2Examples/LAN9250.v
@@ -491,6 +491,7 @@ Section WithParameters.
       erewrite word.unsigned_of_Z in H11.
       exact H11. }
 
+    cbv [HList.tuple.of_list List.app].
     repeat match goal with x := _ |- _ => subst x end.
     cbv [LittleEndian.combine PrimitivePair.pair._1 PrimitivePair.pair._2].
     all : change 32 with Semantics.width in *.
@@ -788,7 +789,7 @@ Section WithParameters.
       change 255 with (Z.ones 8); rewrite Z.land_ones by blia.
       Z.div_mod_to_equations. blia. }
     repeat match goal with x := _ |- _ => subst x end.
-    cbv [LittleEndian.combine PrimitivePair.pair._1 PrimitivePair.pair._2].
+    cbv [LittleEndian.combine HList.tuple.of_list PrimitivePair.pair._1 PrimitivePair.pair._2].
 
     change 32 with Semantics.width.
     repeat rewrite ?Properties.word.unsigned_or_nowrap, <-?Z.lor_assoc by (rewrite ?word.unsigned_of_Z; exact eq_refl).

--- a/bedrock2/src/bedrock2Examples/lightbulb_spec.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb_spec.v
@@ -95,7 +95,7 @@ Section LightbulbSpec.
     spi_end) t /\
     byte.unsigned a1 = word.unsigned (word.sru a (word.of_Z 8)) /\
     byte.unsigned a0 = word.unsigned (word.and a (word.of_Z 255)) /\
-    word.unsigned v = LittleEndian.combine 4 ltac:(repeat split; [exact v0|exact v1|exact v2|exact v3]).
+    word.unsigned v = LittleEndian.combine 4 (HList.tuple.of_list (cons v0 (cons v1 (cons v2 (cons v3 nil))))).
 
   Definition LAN9250_WRITE : byte := Byte.x02.
   Definition HW_CFG : Z := Ox"074".
@@ -113,7 +113,7 @@ Section LightbulbSpec.
     spi_end) t /\
     byte.unsigned a1 = word.unsigned (word.sru a (word.of_Z 8)) /\
     byte.unsigned a0 = word.unsigned (word.and a (word.of_Z 255)) /\
-    word.unsigned v = LittleEndian.combine 4 ltac:(repeat split; [exact v0|exact v1|exact v2|exact v3]).
+    word.unsigned v = LittleEndian.combine 4 (HList.tuple.of_list (cons v0 (cons v1 (cons v2 (cons v3 nil))))).
 
   (* NOTE: we could do this without rounding up to the nearest word, and this
   * might be necessary for other stacks than IP-TCP and IP-UDP *)
@@ -127,7 +127,7 @@ Section LightbulbSpec.
     match bs with
     | nil => eq nil
     | cons v0 (cons v1 (cons v2 (cons v3 bs))) =>
-      lan9250_fastread4 (word.of_Z 0) (word.of_Z (LittleEndian.combine 4 ltac:(repeat split; [exact v0|exact v1|exact v2|exact v3]))) +++
+      lan9250_fastread4 (word.of_Z 0) (word.of_Z (LittleEndian.combine 4 (HList.tuple.of_list (cons v0 (cons v1 (cons v2 (cons v3 nil))))))) +++
       lan9250_readpacket bs
     | _ => constraint False (* TODO: padding? *)
     end.

--- a/bedrock2/src/bedrock2Examples/stackalloc.v
+++ b/bedrock2/src/bedrock2Examples/stackalloc.v
@@ -66,6 +66,9 @@ Section WithParameters.
     set (R := eq m).
     pose proof (eq_refl : R m) as Hm.
     repeat straightline.
+    assert (sep R (scalar32 a (Interface.word.of_Z (LittleEndian.combine _ (HList.tuple.of_list stack)))) m)
+      by admit.
+    repeat straightline.
   Abort.
 
   Instance spec_of_stackdisj : spec_of "stackdisj" := fun functions => forall m t,

--- a/compiler/src/compiler/SeparationLogic.v
+++ b/compiler/src/compiler/SeparationLogic.v
@@ -229,7 +229,7 @@ Section ptstos.
     clear Hsep.
 
     rewrite <-(List.firstn_skipn (Z.to_nat bytes_per_word) bytes) at 1.
-    unfold ptsto_word, truncated_scalar, littleendian.
+    unfold ptsto_word, truncated_word, truncated_scalar, littleendian.
 
     rewrite <-bytearray_index_merge.
     1: eapply Proper_sep_iff1; [|reflexivity].

--- a/compiler/src/compiler/Spilling.v
+++ b/compiler/src/compiler/Spilling.v
@@ -1098,7 +1098,7 @@ Section Spilling.
       iff1 (scalar addr (word.of_Z (head_to_Z (Z.to_nat bytes_per_word) l)))
            (array ptsto (word.of_Z 1) addr (List__firstn_default (Z.to_nat bytes_per_word) l Byte.x00)).
   Proof.
-    unfold scalar, truncated_scalar. intros. rewrite word.unsigned_of_Z. unfold word.wrap.
+    unfold scalar, truncated_word, truncated_scalar. intros. rewrite word.unsigned_of_Z. unfold word.wrap.
   Abort.
 
   (* byte_list_to_word_list_array already exists, TODO reconcile *)


### PR DESCRIPTION
... because the semantics perform all operations on bitwidth-size word anyways, and having only one word instance in scope makes program logic proofs simpler. Also adding a special case for load4/store4 on 32bit machines, where no conversion between the value read/written and machine words is needed.

I hope this will be useful for @bdiehs
/cc @andres-erbsen 