### PR TITLE
Hint Mode + for word and map

### DIFF
--- a/bedrock2/src/bedrock2/AbsintWordToZ.v
+++ b/bedrock2/src/bedrock2/AbsintWordToZ.v
@@ -160,8 +160,6 @@ Module unsigned.
             match reverse goal with H : ?e |- ?G => is_evar e; unify e G; exact H end).. ]
       )) (at level 10, only parsing).
 
-    Lemma absint_of_Z (x : Z) (Hrange : 0 <= x < 2^width) : word.unsigned (word.of_Z (width:=width) x) = x.
-    Proof. rewrite word.unsigned_of_Z; unfold word.wrap; rewrite Z.mod_small; trivial. Qed.
     Definition absint_add (x y : word.rep) ux Hx uy Hy Hbounds : _ =~> _ :=
       absint_lemma! (word.unsigned_add x y).
     Definition absint_sub (x y : word.rep) ux Hx uy Hy Hbounds : word.unsigned _ =~> _ :=
@@ -224,7 +222,7 @@ Module unsigned.
       | _ => match goal with H: word.unsigned e =~> _ |- _ => H end
       | word.of_Z ?a =>
         let Ba := rbounded a in
-        named_pose_proof (absint_of_Z a (boundscheck (X0:=0) (X1:=2^width) Ba (eq_refl true)) : @absint_eq Z (@word.unsigned _ word_parameters e) a)
+        named_pose_proof (word.unsigned_of_Z_nowrap a (boundscheck (X0:=0) (X1:=2^width) Ba (eq_refl true)) : @absint_eq Z (@word.unsigned _ word_parameters e) a)
       | word.and ?a ?b =>
         let Ha := zify_expr a in let Ra := lazymatch type of Ha with _ =~> ?x => x end in
         let Hb := zify_expr b in let Rb := lazymatch type of Hb with _ =~> ?x => x end in

--- a/bedrock2/src/bedrock2/AbsintWordToZ.v
+++ b/bedrock2/src/bedrock2/AbsintWordToZ.v
@@ -160,7 +160,7 @@ Module unsigned.
             match reverse goal with H : ?e |- ?G => is_evar e; unify e G; exact H end).. ]
       )) (at level 10, only parsing).
 
-    Lemma absint_of_Z (x : Z) (Hrange : 0 <= x < 2^width) : word.unsigned (word.of_Z x) = x.
+    Lemma absint_of_Z (x : Z) (Hrange : 0 <= x < 2^width) : word.unsigned (word.of_Z (width:=width) x) = x.
     Proof. rewrite word.unsigned_of_Z; unfold word.wrap; rewrite Z.mod_small; trivial. Qed.
     Definition absint_add (x y : word.rep) ux Hx uy Hy Hbounds : _ =~> _ :=
       absint_lemma! (word.unsigned_add x y).
@@ -184,8 +184,9 @@ Module unsigned.
       absint_lemma! (Properties.word.unsigned_divu_nowrap x y).
     Definition absint_modu (x y : word.rep) ux Hx uy Hy Hnz  : word.unsigned _ =~> _ :=
       absint_lemma! (Properties.word.unsigned_modu_nowrap x y).
+    Implicit Types (x y : word).
     (* TODO use it *)
-    Lemma absint_opp (x : word.rep) (ux: Z) (Hx: word.unsigned x = ux) (Hnz: ux <> 0):
+    Lemma absint_opp x (ux: Z) (Hx: word.unsigned x = ux) (Hnz: ux <> 0):
       word.unsigned (word.opp x) =~> 2^width - ux.
     Proof.
       rewrite word.unsigned_opp. cbv [word.wrap].

--- a/bedrock2/src/bedrock2/Array.v
+++ b/bedrock2/src/bedrock2/Array.v
@@ -120,7 +120,7 @@ Section Array.
       repeat (rewrite ?word.unsigned_sub, ?Zdiv.Zminus_mod_idemp_r, ?Zdiv.Zminus_mod_idemp_l, ?Zdiv.Zplus_mod_idemp_r, ?Zdiv.Zplus_mod_idemp_l || unfold word.wrap).
       replace (word.unsigned start + (word.unsigned a - word.unsigned start)) with (word.unsigned a) by blia.
       rewrite Z.mod_small by assumption; trivial. }
-    replace (word.mul (word.of_Z (Z.of_nat n)) size) with (word.of_Z (word.unsigned size * Z.of_nat n)); cycle 1.
+    replace (word.mul (word.of_Z (Z.of_nat n)) size) with (word.of_Z (width:=width) (word.unsigned size * Z.of_nat n)); cycle 1.
     { eapply word.unsigned_inj.
       repeat (rewrite ?word.unsigned_of_Z, ?word.unsigned_mul, ?Zdiv.Zmult_mod_idemp_r, ?Zdiv.Zmult_mod_idemp_l || unfold word.wrap).
       f_equal. blia. }

--- a/bedrock2/src/bedrock2/Array.v
+++ b/bedrock2/src/bedrock2/Array.v
@@ -3,6 +3,7 @@ Require Import Coq.Lists.List Coq.ZArith.BinInt. Local Open Scope Z_scope.
 Require Import coqutil.Word.Interface coqutil.Word.Properties.
 Require Import coqutil.Z.Lia.
 Require Import coqutil.Byte.
+Require Import coqutil.Tactics.eplace.
 
 Section Array.
   Context {width : Z} {word : Word.Interface.word width} {word_ok : word.ok word}.
@@ -120,7 +121,7 @@ Section Array.
       repeat (rewrite ?word.unsigned_sub, ?Zdiv.Zminus_mod_idemp_r, ?Zdiv.Zminus_mod_idemp_l, ?Zdiv.Zplus_mod_idemp_r, ?Zdiv.Zplus_mod_idemp_l || unfold word.wrap).
       replace (word.unsigned start + (word.unsigned a - word.unsigned start)) with (word.unsigned a) by blia.
       rewrite Z.mod_small by assumption; trivial. }
-    replace (word.mul (word.of_Z (Z.of_nat n)) size) with (word.of_Z (width:=width) (word.unsigned size * Z.of_nat n)); cycle 1.
+    eplace (word.mul (word.of_Z (Z.of_nat n)) size) with (word.of_Z (word.unsigned size * Z.of_nat n)).
     { eapply word.unsigned_inj.
       repeat (rewrite ?word.unsigned_of_Z, ?word.unsigned_mul, ?Zdiv.Zmult_mod_idemp_r, ?Zdiv.Zmult_mod_idemp_l || unfold word.wrap).
       f_equal. blia. }

--- a/bedrock2/src/bedrock2/Map/Separation.v
+++ b/bedrock2/src/bedrock2/Map/Separation.v
@@ -2,10 +2,10 @@ Require Import coqutil.Map.Interface bedrock2.Lift1Prop. Import map.
 
 Section Sep.
   Context {key value} {map : map key value}.
-  Definition emp (P : Prop) := fun m => m = empty /\ P.
-  Definition sep (p q : rep -> Prop) m :=
+  Definition emp (P : Prop) := fun m : map => m = empty /\ P.
+  Definition sep (p q : map -> Prop) m :=
     exists mp mq, split m mp mq /\ p mp /\ q mq.
-  Definition ptsto k v := fun m => m = put empty k v.
+  Definition ptsto k v := fun m : map => m = put empty k v.
   Definition read k (P : value -> rep -> Prop) := (ex1 (fun v => sep (ptsto k v) (P v))).
 
   Fixpoint seps (xs : list (rep -> Prop)) : rep -> Prop :=

--- a/bedrock2/src/bedrock2/Map/SeparationLogic.v
+++ b/bedrock2/src/bedrock2/Map/SeparationLogic.v
@@ -12,8 +12,8 @@ Section SepProperties.
   Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
   Local Open Scope sep_scope.
 
-  Global Instance Proper_sep_iff1 : Proper (iff1 ==> iff1 ==> iff1) sep. firstorder idtac. Qed.
-  Global Instance Proper_sep_impl1 : Proper (impl1 ==> impl1 ==> impl1) sep. firstorder idtac. Qed.
+  Global Instance Proper_sep_iff1 : Proper (@iff1 map ==> iff1 ==> iff1) sep. firstorder idtac. Qed.
+  Global Instance Proper_sep_impl1 : Proper (@impl1 map ==> impl1 ==> impl1) sep. firstorder idtac. Qed.
 
   Ltac t :=
     repeat match goal with
@@ -24,6 +24,8 @@ Section SepProperties.
     | H:disjoint _ (putmany _ _) |- _ => eapply disjoint_putmany_r in H; destruct H
     | _ => progress intuition idtac
     end.
+
+  Implicit Types (p q r : map -> Prop) (k : key) (v : value) (m : map).
 
   (* sep and sep *)
   Lemma sep_comm p q : iff1 (p*q) (q*p).
@@ -96,20 +98,20 @@ Section SepProperties.
     { intros (?&?&(?&?)&?&?); subst; trivial. }
   Qed.
 
-  Lemma iff1_sep_cancel P Q1 Q2 (H : iff1 Q1 Q2) : iff1 (P * Q1) (P * Q2).
+  Lemma iff1_sep_cancel p q1 q2 (H : iff1 q1 q2) : iff1 (p * q1) (p * q2).
   Proof. exact (Proper_sep_iff1 _ _ (reflexivity _) _ _ H). Qed.
 
   (* More Conntectives *)
-  Global Instance Proper_emp_iff : Proper (iff ==> iff1) emp. firstorder idtac. Qed.
-  Global Instance Proper_emp_impl : Proper (Basics.impl ==> impl1) emp. firstorder idtac. Qed.
+  Global Instance Proper_emp_iff : Proper (iff ==> @iff1 map) emp. firstorder idtac. Qed.
+  Global Instance Proper_emp_impl : Proper (Basics.impl ==> @impl1 map) emp. firstorder idtac. Qed.
 
   (* sep and emp *)
-  Lemma sep_emp_emp p q : iff1 (sep (emp p) (emp q)) (emp (p /\ q)).
+  Lemma sep_emp_emp P Q : @iff1 map (sep (emp P) (emp Q)) (emp (P /\ Q)).
   Proof. cbv [iff1 sep emp split]; t; intuition eauto 20 using putmany_empty_l, disjoint_empty_l. Qed.
-  Lemma sep_comm_emp_r a b : iff1 (a * emp b) (emp b * a). eapply sep_comm. Qed.
-  Lemma sep_emp_2 a b c : iff1 (a * (emp b * c)) (emp b * (a * c)).
-  Proof. rewrite <-sep_assoc. rewrite (sep_comm a). rewrite sep_assoc. reflexivity. Qed.
-  Lemma sep_emp_12 a b c : iff1 (emp a * (emp b * c)) (emp (a /\ b) * c).
+  Lemma sep_comm_emp_r p Q : iff1 (p * emp Q) (emp Q * p). eapply sep_comm. Qed.
+  Lemma sep_emp_2 p Q r : iff1 (p * (emp Q * r)) (emp Q * (p * r)).
+  Proof. rewrite <-sep_assoc. rewrite (sep_comm p). rewrite sep_assoc. reflexivity. Qed.
+  Lemma sep_emp_12 P Q r : iff1 (emp P * (emp Q * r)) (emp (P /\ Q) * r).
   Proof. rewrite <-sep_assoc. rewrite sep_emp_emp. reflexivity. Qed.
 
   Lemma sep_emp_l a b m : sep (emp a) b m <-> a /\ b m.
@@ -137,13 +139,13 @@ Section SepProperties.
   Proof. rewrite sep_comm. rewrite sep_ex1_r. setoid_rewrite (sep_comm p). reflexivity. Qed.
 
   (* impl1 and emp *)
-  Lemma impl1_l_sep_emp (a:Prop) b c : impl1 (emp a * b) c <-> (a -> impl1 b c).
+  Lemma impl1_l_sep_emp (a:Prop) r c : impl1 (emp a * r) c <-> (a -> impl1 r c).
   Proof. cbv [impl1 emp sep split]; t; rewrite ?putmany_empty_l; eauto 10 using putmany_empty_l, disjoint_empty_l. Qed.
-  Lemma impl1_r_sep_emp a b c : (b /\ impl1 a c) -> impl1 a (emp b * c).
+  Lemma impl1_r_sep_emp p b c : (b /\ impl1 p c) -> impl1 p (emp b * c).
   Proof. cbv [impl1 emp sep split]; t; eauto 10 using putmany_empty_l, disjoint_empty_l. Qed.
 
 (** shallow reflection from a list of predicates for faster cancellation proofs *)
-  Fixpoint seps' (xs : list (rep -> Prop)) : rep -> Prop :=
+  Fixpoint seps' (xs : list (map -> Prop)) : map -> Prop :=
     match xs with
     | cons x xs => sep x (seps' xs)
     | nil => emp True
@@ -155,10 +157,10 @@ Section SepProperties.
     eapply Proper_sep_iff1, IHxs.
     exact (reflexivity _).
   Qed.
-  Lemma seps_cons(P: rep -> Prop)(Ps: list (rep -> Prop)):
+  Lemma seps_cons(P: map -> Prop)(Ps: list (map -> Prop)):
     iff1 (seps (P :: Ps)) (sep P (seps Ps)).
   Proof. rewrite <-! seps'_iff1_seps. reflexivity. Qed.
-  Lemma seps_app(Ps Qs: list (rep -> Prop)):
+  Lemma seps_app(Ps Qs: list (map -> Prop)):
     iff1 (seps (Ps ++ Qs)) (sep (seps Ps) (seps Qs)).
   Proof.
     induction Ps.
@@ -174,8 +176,8 @@ Section SepProperties.
   Definition app {T} := Eval cbv delta in @List.app T.
 
   Local Infix "++" := app. Local Infix "++" := app : list_scope.
-  Let nth n xs := hd (emp True) (skipn n xs).
-  Let remove_nth n (xs : list (rep -> Prop)) :=
+  Let nth n xs := hd (emp(map:=map) True) (skipn n xs).
+  Let remove_nth n (xs : list (map -> Prop)) :=
     (firstn n xs ++ tl (skipn n xs)).
 
   Lemma seps_nth_to_head n xs : iff1 (sep (nth n xs) (seps (remove_nth n xs))) (seps xs).

--- a/bedrock2/src/bedrock2/Scalars.v
+++ b/bedrock2/src/bedrock2/Scalars.v
@@ -15,6 +15,7 @@ Section Scalars.
   Context {width : Z} {word : Word.Interface.word width} {word_ok : word.ok word}.
 
   Context {mem : map.map word byte} {mem_ok : map.ok mem}.
+  Implicit Types (m : mem).
 
   Definition littleendian (n : nat) (addr : word) (value : Z) : mem -> Prop :=
     ptsto_bytes n addr (LittleEndian.split n value).

--- a/bedrock2/src/bedrock2/Semantics.v
+++ b/bedrock2/src/bedrock2/Semantics.v
@@ -264,3 +264,7 @@ Module exec. Section WithEnv.
   End WithEnv.
   Arguments exec {_} _.
 End exec. Notation exec := exec.exec.
+
+Module word.
+  Notation of_Z := (word.of_Z (word:=word)).
+End word.

--- a/bedrock2/src/bedrock2/WeakestPrecondition.v
+++ b/bedrock2/src/bedrock2/WeakestPrecondition.v
@@ -4,6 +4,7 @@ Require Import coqutil.dlet bedrock2.Syntax bedrock2.Semantics.
 
 Section WeakestPrecondition.
   Context {p : unique! Semantics.parameters}.
+  Implicit Types (t : trace) (m : mem) (l : locals).
 
   Definition literal v (post : word -> Prop) : Prop :=
     dlet! v := word.of_Z v in post v.

--- a/bedrock2/src/bedrock2/ZnWords.v
+++ b/bedrock2/src/bedrock2/ZnWords.v
@@ -64,7 +64,7 @@ Module word.
         unfold word.wrap; rewrite (Z.mod_small a); blia.
     Qed.
 
-    Lemma unsigned_if: forall (b: bool) thn els,
+    Lemma unsigned_if: forall (b: bool) (thn els : word),
         word.unsigned (if b then thn else els) = if b then word.unsigned thn else word.unsigned els.
     Proof. intros. destruct b; reflexivity. Qed.
   End WithWord.

--- a/bedrock2/src/bedrock2/footpr.v
+++ b/bedrock2/src/bedrock2/footpr.v
@@ -129,7 +129,7 @@ Section Footprint.
     eapply footpr_sep_subset_l. eassumption.
   Qed.
 
-  Lemma same_domain_split: forall m1 m2 m1l m1r m2l m2r,
+  Lemma same_domain_split: forall (m1 m2 m1l m1r m2l m2r : map),
       map.same_domain m1l m2l ->
       map.same_domain m1r m2r ->
       map.split m1 m1l m1r ->

--- a/bedrock2/src/bedrock2Examples/ARPResponderProofs.v
+++ b/bedrock2/src/bedrock2Examples/ARPResponderProofs.v
@@ -1,5 +1,6 @@
 From Coq Require Import Strings.String Lists.List ZArith.BinInt.
-From bedrock2 Require Import BasicC32Semantics ProgramLogic.
+From coqutil.Word Require Import Interface.
+From bedrock2 Require Import Semantics BasicC32Semantics ProgramLogic.
 Require Import coqutil.Byte.
 Require Import coqutil.Z.Lia.
 
@@ -7,7 +8,6 @@ Require Import bedrock2Examples.ARPResponder.
 
 Import Datatypes List ListNotations.
 Local Open Scope string_scope. Local Open Scope list_scope. Local Open Scope Z_scope.
-From coqutil.Word Require Import Interface.
 
 From bedrock2 Require Import Array Scalars Separation.
 From coqutil.Tactics Require Import letexists rdelta.
@@ -47,7 +47,7 @@ Goal program_logic_goal_for_function! arp.
     SeparationLogic.seprewrite_in @array_index_nat_inbounds H;
     [instantiate (1 := iNat); blia|match goal with H : _ |- _ => instantiate (1 := byte.of_Z 0) in H end];
     eapply load_one_of_sep;
-    change (word.of_Z (word.unsigned (word.of_Z(width:=?w) 1) * Z.of_nat iNat)) with (word.of_Z(width:=w) i) in *;
+    change (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat iNat)) with (word.of_Z i) in *;
     SeparationLogic.ecancel_assumption
   end end.
 
@@ -70,7 +70,7 @@ Goal program_logic_goal_for_function! arp.
     SeparationLogic.seprewrite_in @array_index_nat_inbounds H;
     [instantiate (1 := iNat); blia|match goal with H : _ |- _ => instantiate (1 := byte.of_Z 0) in H end];
     eapply store_one_of_sep;
-    change (word.of_Z (word.unsigned (word.of_Z(width:=?w) 1) * Z.of_nat iNat)) with (word.of_Z(width:=w) i) in *;
+    change (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat iNat)) with (word.of_Z i) in *;
     [SeparationLogic.ecancel_assumption|]
   end end.
 

--- a/bedrock2/src/bedrock2Examples/ARPResponderProofs.v
+++ b/bedrock2/src/bedrock2Examples/ARPResponderProofs.v
@@ -47,7 +47,7 @@ Goal program_logic_goal_for_function! arp.
     SeparationLogic.seprewrite_in @array_index_nat_inbounds H;
     [instantiate (1 := iNat); blia|match goal with H : _ |- _ => instantiate (1 := byte.of_Z 0) in H end];
     eapply load_one_of_sep;
-    change (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat iNat)) with (word.of_Z i) in *;
+    change (word.of_Z (word.unsigned (word.of_Z(width:=?w) 1) * Z.of_nat iNat)) with (word.of_Z(width:=w) i) in *;
     SeparationLogic.ecancel_assumption
   end end.
 
@@ -70,7 +70,7 @@ Goal program_logic_goal_for_function! arp.
     SeparationLogic.seprewrite_in @array_index_nat_inbounds H;
     [instantiate (1 := iNat); blia|match goal with H : _ |- _ => instantiate (1 := byte.of_Z 0) in H end];
     eapply store_one_of_sep;
-    change (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat iNat)) with (word.of_Z i) in *;
+    change (word.of_Z (word.unsigned (word.of_Z(width:=?w) 1) * Z.of_nat iNat)) with (word.of_Z(width:=w) i) in *;
     [SeparationLogic.ecancel_assumption|]
   end end.
 

--- a/bedrock2/src/bedrock2Examples/ARPResponder_live.v
+++ b/bedrock2/src/bedrock2Examples/ARPResponder_live.v
@@ -19,39 +19,6 @@ Require Import bedrock2.ZnWords.
 Require Import coqutil.Word.SimplWordExpr.
 Require Import bedrock2.footpr.
 
-(* TODO put into coqutil and also use in lightbulb.v *)
-Module word. Section WithWord.
-  Import ZArith.
-  Local Open Scope Z_scope.
-  Context {width} {word: word.word width} {ok : word.ok word}.
-  Lemma unsigned_of_Z_nowrap x:
-    0 <= x < 2 ^ width -> word.unsigned (word.of_Z (width:=width) x) = x.
-  Proof.
-    intros. rewrite word.unsigned_of_Z. unfold word.wrap. rewrite Z.mod_small; trivial.
-  Qed.
-  Lemma of_Z_inj_small{x y}:
-    word.of_Z x = word.of_Z y :> word -> 0 <= x < 2 ^ width -> 0 <= y < 2 ^ width -> x = y.
-  Proof.
-    intros. apply (f_equal word.unsigned) in H. rewrite ?word.unsigned_of_Z in H.
-    unfold word.wrap in H. rewrite ?Z.mod_small in H by assumption. assumption.
-  Qed.
-
-  Lemma and_bool_to_word: forall (b1 b2: bool),
-    word.and (if b1 then word.of_Z 1 else word.of_Z 0)
-             (if b2 then word.of_Z 1 else word.of_Z 0) =
-    (if (andb b1 b2) then word.of_Z 1 else word.of_Z 0) :> word.
-  Proof.
-    assert (1 < 2 ^ width). {
-      pose proof word.width_pos.
-      change 1 with (2 ^ 0). apply Z.pow_lt_mono_r; blia.
-    }
-    destruct b1; destruct b2; simpl; apply word.unsigned_inj; rewrite word.unsigned_and;
-      unfold word.wrap; rewrite ?unsigned_of_Z_nowrap by blia;
-        rewrite ?Z.land_diag, ?Z.land_0_r, ?Z.land_0_l;
-        apply Z.mod_small; blia.
-  Qed.
-End WithWord. End word.
-
 Module List.
   Import List.ListNotations. Open Scope list_scope.
   Section MapWithIndex.
@@ -1204,16 +1171,6 @@ Ltac ring_simplify_hyp_rec t H :=
 Ltac ring_simplify_hyp H :=
   let t := type of H in ring_simplify_hyp_rec t H.
 
-Lemma if_then_1_else_0_eq_0: forall (b: bool),
-    word.unsigned (if b then word.of_Z 1 else word.of_Z (width:=width) 0) = 0 ->
-    b = false.
-Proof. intros; destruct b; [exfalso|reflexivity]. ZnWords. Qed.
-
-Lemma if_then_1_else_0_neq_0: forall (b: bool),
-    word.unsigned (if b then word.of_Z 1 else word.of_Z (width:=width) 0) <> 0 ->
-    b = true.
-Proof. intros; destruct b; [reflexivity|exfalso]. ZnWords. Qed.
-
 Ltac simpli_getEq t :=
   match t with
   | context[@word.and ?wi ?wo (if ?b1 then _ else _) (if ?b2 then _ else _)] =>
@@ -1226,8 +1183,8 @@ Ltac simpli_getEq t :=
 Ltac simpli :=
   repeat ((rewr simpli_getEq in *  by ZnWords) ||
          match goal with
-         | H: word.unsigned (if ?b then _ else _) = 0 |- _ => apply if_then_1_else_0_eq_0 in H
-         | H: word.unsigned (if ?b then _ else _) <> 0 |- _ => apply if_then_1_else_0_neq_0 in H
+         | H: word.unsigned (if ?b then _ else _) = 0 |- _ => apply word.if_zero in H
+         | H: word.unsigned (if ?b then _ else _) <> 0 |- _ => apply word.if_nonzero in H
          | H: word.eqb ?x ?y = true  |- _ => apply (word.eqb_true  x y) in H
          | H: word.eqb ?x ?y = false |- _ => apply (word.eqb_false x y) in H
          | H: andb ?b1 ?b2 = true |- _ => apply (Bool.andb_true_iff b1 b2) in H

--- a/bedrock2/src/bedrock2Examples/FE310CompilerDemo.v
+++ b/bedrock2/src/bedrock2Examples/FE310CompilerDemo.v
@@ -115,7 +115,7 @@ Compute swap_chars_over_uart.
 Require Import bedrock2.ProgramLogic coqutil.Map.Interface.
 Import Coq.Lists.List. Import ListNotations.
 
-Local Opaque word.of_Z.
+Local Opaque Word.Interface.word.of_Z.
 Module Z.
   Lemma land_nonzero a b : Z.land a b <> 0 -> a <> 0 /\ b <> 0.
   Proof.

--- a/bedrock2/src/bedrock2Examples/FlatConstMem.v
+++ b/bedrock2/src/bedrock2Examples/FlatConstMem.v
@@ -247,11 +247,11 @@ Section WithParameters.
 
   Lemma of_list_word_nil
     [value] [map : map.map word value] {ok : map.ok map}
-    k : []$@k = empty.
+    k : []$@k = empty(map:=map).
   Proof. apply Properties.map.fold_empty. Qed.
   Lemma of_list_word_singleton
     [value] [map : map.map word value] {ok : map.ok map}
-    k v : [v]$@k = put empty k v.
+    (k : word) (v : value) : [v]$@k = put empty k v.
   Proof.
     cbv [of_list_word_at of_list_word seq length List.map of_func update].
     rewrite word.unsigned_of_Z_0, Z2Nat.inj_0; cbv [MapKeys.map.map_keys nth_error].
@@ -320,7 +320,7 @@ Section WithParameters.
 
   Section __.
     Import WithoutTuples.
-    Lemma load_bytes_of_putmany_bytes_at bs a mR n (Hn : length bs = n) (Hl : Z.of_nat n < 2^width)
+    Lemma load_bytes_of_putmany_bytes_at bs a (mR:mem) n (Hn : length bs = n) (Hl : Z.of_nat n < 2^width)
       : load_bytes (mR $+ bs$@a) a n = Some bs.
     Proof.
       destruct (load_bytes (mR $+ bs$@a) a n) eqn:HN in *; cycle 1.
@@ -343,7 +343,7 @@ Section WithParameters.
       congruence.
     Qed.
 
-    Lemma load_bytes_of_sep_bytes_at bs a R m (Hsep: (eq(bs$@a)*R) m) n (Hn : length bs = n) (Hl : Z.of_nat n < 2^width)
+    Lemma load_bytes_of_sep_bytes_at bs a R (m:mem) (Hsep: (eq(bs$@a)*R) m) n (Hn : length bs = n) (Hl : Z.of_nat n < 2^width)
       : load_bytes m a n = Some bs.
     Proof.
       eapply sep_comm in Hsep.
@@ -352,7 +352,7 @@ Section WithParameters.
     Qed.
   End __.
 
-  Lemma load_four_bytes_of_sep_at bs a R m (Hsep: (eq(bs$@a)*R) m) (Hl : length bs = 4%nat) :
+  Lemma load_four_bytes_of_sep_at bs a R (m:mem) (Hsep: (eq(bs$@a)*R) m) (Hl : length bs = 4%nat) :
     load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
   Proof.
     eapply Scalars.load_four_bytes_of_sep_at; try eassumption. reflexivity.

--- a/bedrock2/src/bedrock2Examples/SPI.v
+++ b/bedrock2/src/bedrock2Examples/SPI.v
@@ -1,6 +1,7 @@
 Require Import bedrock2.Syntax bedrock2.NotationsCustomEntry coqutil.Z.HexNotation.
 Require Import coqutil.Z.div_mod_to_equations.
 Require Import coqutil.Z.Lia.
+Require Import coqutil.Word.Interface.
 Require Import coqutil.Byte.
 
 Import BinInt String List.ListNotations ZArith.
@@ -57,8 +58,7 @@ Definition spi_xchg : function :=
   ))).
 
 Require Import bedrock2.ProgramLogic.
-Require Import bedrock2.FE310CSemantics.
-Require Import coqutil.Word.Interface.
+Require Import bedrock2.FE310CSemantics bedrock2.Semantics.
 Require Import Coq.Lists.List. Import ListNotations.
 Require Import bedrock2.TracePredicate. Import TracePredicateNotations.
 Require Import bedrock2.ZnWords.
@@ -90,7 +90,7 @@ Section WithParameters.
         (word.unsigned err <> 0 /\ lightbulb_spec.spi_read_empty _ ^* ioh /\ Z.of_nat (length ioh) = patience)
         (word.unsigned err = 0 /\ lightbulb_spec.spi_read parameters.word b ioh)).
 
-  Lemma nonzero_because_high_bit_set x (H : word.unsigned (word.sru x (word.of_Z 31)) <> 0)
+  Lemma nonzero_because_high_bit_set (x : word) (H : word.unsigned (word.sru x (word.of_Z 31)) <> 0)
     : word.unsigned x <> 0.
   Proof. ZnWords. Qed.
 

--- a/bedrock2/src/bedrock2Examples/SPI_live.v
+++ b/bedrock2/src/bedrock2Examples/SPI_live.v
@@ -98,7 +98,7 @@ Section WithParameters.
          morphism (Properties.word.ring_morph (word := Semantics.word)),
          constants [Properties.word_cst]).
 
-  Lemma nonzero_because_high_bit_set x (H : word.unsigned (word.sru x (word.of_Z 31)) <> 0)
+  Lemma nonzero_because_high_bit_set (x : word) (H : word.unsigned (word.sru x (word.of_Z 31)) <> 0)
     : word.unsigned x <> 0.
   Proof.
     rewrite Properties.word.unsigned_sru_nowrap in H.
@@ -605,7 +605,7 @@ Section WithParameters.
           rewrite word.unsigned_of_Z in H1; eapply H1. }
         { rewrite app_length, Znat.Nat2Z.inj_add; cbn [app Datatypes.length]. subst v3.
           unshelve erewrite (_ : patience = _); [|symmetry; eassumption|].
-          replace 0 with (word.unsigned (word.of_Z 0)) in H0; cycle 1.
+          replace 0 with (word.unsigned (word.of_Z(width:=width) 0)) in H0; cycle 1.
           { rewrite word.unsigned_of_Z; exact eq_refl. }
           eapply Properties.word.unsigned_inj in H0.
           subst b1. destruct_one_match_hyp. {

--- a/bedrock2/src/bedrock2Examples/SPI_live.v
+++ b/bedrock2/src/bedrock2Examples/SPI_live.v
@@ -463,9 +463,7 @@ Section WithParameters.
         eexists. split.
         { eexists. eexists. split. {
             subst l'.
-            cbv -[v1 v2 v3 parameters.word(*<--otherwise different implicits won't be recognized by destruct*)
-                     word.eqb word.xor word.sru word.of_Z].
-            reflexivity. (* takes some time, but whatever *)
+            reflexivity.
           }
           split; [reflexivity|].
           subst b1.
@@ -605,7 +603,7 @@ Section WithParameters.
           rewrite word.unsigned_of_Z in H1; eapply H1. }
         { rewrite app_length, Znat.Nat2Z.inj_add; cbn [app Datatypes.length]. subst v3.
           unshelve erewrite (_ : patience = _); [|symmetry; eassumption|].
-          replace 0 with (word.unsigned (word.of_Z(width:=width) 0)) in H0; cycle 1.
+          replace 0 with (word.unsigned (word.of_Z 0)) in H0; cycle 1.
           { rewrite word.unsigned_of_Z; exact eq_refl. }
           eapply Properties.word.unsigned_inj in H0.
           subst b1. destruct_one_match_hyp. {

--- a/bedrock2/src/bedrock2Examples/Trace.v
+++ b/bedrock2/src/bedrock2Examples/Trace.v
@@ -73,6 +73,7 @@ Module SpiEth.
   Definition MMOutput := "MMOutput"%string.
 
   Section WithMem.
+    Import Word.Interface.
     Context {word: word.word 32} {mem: map.map word Byte.byte} {mem_ok: map.ok mem}.
     Context {word_ok: word.ok word}.
 
@@ -218,6 +219,7 @@ Module Syscalls.
   Section WithMem.
     Context {word: word.word 32} {mem: map.map word Byte.byte} {mem_ok: map.ok mem}.
     Context {word_ok: word.ok word}.
+    Import Word.Interface.
 
     Definition Event: Type := (mem * SyscallAction * list word) * (mem * list word).
 

--- a/bedrock2/src/bedrock2Examples/indirect_add.v
+++ b/bedrock2/src/bedrock2Examples/indirect_add.v
@@ -25,7 +25,7 @@ Require Import bedrock2.ProgramLogic bedrock2.Scalars.
 Section WithParameters.
   Context {p : FE310CSemantics.parameters}.
 
-  Definition f a b := word.add (word.add a b) b.
+  Definition f (a b : Semantics.word) := word.add (word.add a b) b.
 
   Local Notation "m =* P" := (P%sep m) (at level 70, only parsing). (* experiment *)
   Instance spec_of_indirect_add : spec_of "indirect_add" :=
@@ -71,7 +71,7 @@ Section WithParameters.
     indirect_add(a, a, c)
   ))).
 
-  Definition g a b c := word.add (word.add a b) c.
+  Definition g (a b c : Semantics.word) := word.add (word.add a b) c.
   Instance spec_of_indirect_add_three : spec_of "indirect_add_three" :=
     fnspec! "indirect_add_three" a b c / va vb vc Rb R,
     { requires t m := m =* scalar a va * scalar c vc * R /\ m =* scalar b vb * Rb;

--- a/bedrock2/src/bedrock2Examples/indirect_add.v
+++ b/bedrock2/src/bedrock2Examples/indirect_add.v
@@ -15,8 +15,8 @@ Definition indirect_add_twice : func := let a := "a" in let b := "b" in
 ))).
 
 Require Import bedrock2.WeakestPrecondition.
-Require Import bedrock2.Semantics bedrock2.FE310CSemantics.
 Require Import coqutil.Word.Interface coqutil.Map.Interface bedrock2.Map.SeparationLogic.
+Require Import bedrock2.Semantics bedrock2.FE310CSemantics.
 
 Require bedrock2.WeakestPreconditionProperties.
 From coqutil.Tactics Require Import letexists eabstract.
@@ -25,7 +25,7 @@ Require Import bedrock2.ProgramLogic bedrock2.Scalars.
 Section WithParameters.
   Context {p : FE310CSemantics.parameters}.
 
-  Definition f (a b : Semantics.word) := word.add (word.add a b) b.
+  Definition f (a b : word) := word.add (word.add a b) b.
 
   Local Notation "m =* P" := (P%sep m) (at level 70, only parsing). (* experiment *)
   Instance spec_of_indirect_add : spec_of "indirect_add" :=
@@ -71,7 +71,7 @@ Section WithParameters.
     indirect_add(a, a, c)
   ))).
 
-  Definition g (a b c : Semantics.word) := word.add (word.add a b) c.
+  Definition g (a b c : word) := word.add (word.add a b) c.
   Instance spec_of_indirect_add_three : spec_of "indirect_add_three" :=
     fnspec! "indirect_add_three" a b c / va vb vc Rb R,
     { requires t m := m =* scalar a va * scalar c vc * R /\ m =* scalar b vb * Rb;

--- a/bedrock2/src/bedrock2Examples/lightbulb.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb.v
@@ -359,7 +359,8 @@ Section WithParameters.
       eapply word.unsigned_inj.
       rewrite ?byte_mask_byte.
       rewrite ?word.unsigned_and_nowrap.
-      progress replace (word.unsigned (Word.Interface.word.of_Z 1)) with (Z.ones 1) by (rewrite word.unsigned_of_Z; exact eq_refl). (* PARAMRECORDS*)
+      rewrite word.unsigned_of_Z_1.
+      change 1 with (Z.ones 1).
       rewrite Z.land_ones, Z.bit0_mod by blia.
       rewrite !word.unsigned_of_Z.
       cbv [word.wrap]; change width with 32 in *.

--- a/bedrock2/src/bedrock2Examples/lightbulb.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb.v
@@ -407,7 +407,7 @@ Section WithParameters.
          List.length RECV = List.length scratch /\
          exists iol, T = iol ++ t /\ exists ioh, mmio_trace_abstraction_relation ioh iol /\
          (word.unsigned ERR = 0 /\ lan9250_readpacket _ RECV ioh \/
-          word.unsigned ERR = 2^32-1 /\ TracePredicate.concat TracePredicate.any (spi_timeout word) ioh ) )
+          word.unsigned ERR = 2^32-1 /\ TracePredicate.concat TracePredicate.any (spi_timeout _) ioh ) )
       )
       _ _ _ _ _ _ _ _);
     (* TODO wrap this into a tactic with the previous refine? *)

--- a/bedrock2/src/bedrock2Examples/lightbulb.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb.v
@@ -359,7 +359,7 @@ Section WithParameters.
       eapply word.unsigned_inj.
       rewrite ?byte_mask_byte.
       rewrite ?word.unsigned_and_nowrap.
-      replace (word.unsigned (word.of_Z 1)) with (Z.ones 1) by (rewrite word.unsigned_of_Z; exact eq_refl).
+      progress replace (word.unsigned (Word.Interface.word.of_Z 1)) with (Z.ones 1) by (rewrite word.unsigned_of_Z; exact eq_refl). (* PARAMRECORDS*)
       rewrite Z.land_ones, Z.bit0_mod by blia.
       rewrite !word.unsigned_of_Z.
       cbv [word.wrap]; change width with 32 in *.

--- a/bedrock2/src/bedrock2Examples/lightbulb_spec.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb_spec.v
@@ -12,7 +12,7 @@ Section LightbulbSpec.
   Implicit Types v : word.
 
   Declare Scope word_scope.
-  Notation "! n" := (word.of_Z (width:=width) n) (at level 0, n at level 0, format "! n") : word_scope.
+  Notation "! n" := (word.of_Z n) (at level 0, n at level 0, format "! n") : word_scope.
   Notation "# n" := (Z.of_nat n) (at level 0, n at level 0, format "# n") : word_scope.
   Infix "+" := word.add : word_scope.
   Infix "-" := word.sub : word_scope.
@@ -29,7 +29,7 @@ Section LightbulbSpec.
   Definition OP: Type := (string * word * word).
 
   (** FE310 GPIO *)
-  Definition GPIO_DATA_ADDR := ! (Ox"1001200c").
+  Definition GPIO_DATA_ADDR : word := word.of_Z (Ox"1001200c").
   (* i < 32, only some GPIOs are connected to external pins *)
   Definition gpio_set (i:Z) value :=
     existsl (fun v =>
@@ -174,7 +174,7 @@ Section LightbulbSpec.
 
   (** lightbulb *)
   Definition lightbulb_packet_rep cmd (buf : list byte) := (
-    let idx i buf := word.of_Z (width:=width) (byte.unsigned (List.hd Byte.x00 (List.skipn i buf))) in
+    let idx i buf : word := word.of_Z (byte.unsigned (List.hd Byte.x00 (List.skipn i buf))) in
     42 < Z.of_nat (List.length buf) /\
     1535 < word.unsigned ((word.or (word.slu (idx 12%nat buf) (word.of_Z 8)) (idx 13%nat buf))) /\
     idx 23%nat buf = word.of_Z (Ox"11") /\

--- a/compiler/src/compiler/CompilerInvariant.v
+++ b/compiler/src/compiler/CompilerInvariant.v
@@ -79,7 +79,7 @@ Section Pipeline1.
       auto.
   Qed.
 
-  Lemma ptsto_bytes_range: forall bs start pastend m a v,
+  Lemma ptsto_bytes_range: forall bs (start pastend : FlatImp.word) m a v,
       ptsto_bytes start bs m ->
       word.unsigned start + Z.of_nat (List.length bs) <= word.unsigned pastend ->
       map.get m a = Some v ->
@@ -108,7 +108,7 @@ Section Pipeline1.
           -- destruct width_cases as [F|F]; simpl in *; rewrite F; reflexivity.
          * rewrite word.unsigned_of_Z.
            unfold word.wrap.
-           replace (1 mod 2 ^ FlatImp.width) with 1. 1: blia.
+           replace (1 mod 2 ^ width) with 1. 1: blia.
            simpl.
            destruct width_cases as [F|F]; simpl in *; rewrite F; reflexivity.
       + unfold map.split in *. simp.

--- a/compiler/src/compiler/CompilerInvariant.v
+++ b/compiler/src/compiler/CompilerInvariant.v
@@ -49,6 +49,7 @@ Section Pipeline1.
       apply IHinstrs1.
   Qed.
 
+  (* PARAMRECORDS: "unfold imem" below relies on the syntactic form of this definition. *)
   Definition imem(code_start code_pastend: Semantics.word)(instrs: list Instruction): Semantics.mem -> Prop :=
     (ptsto_bytes (word:=word)(mem:=(@Pipeline.mem p)) code_start (instrencode instrs) *
      mem_available (word.add code_start (word.of_Z (Z.of_nat (List.length (instrencode instrs)))))

--- a/compiler/src/compiler/FlatImp.v
+++ b/compiler/src/compiler/FlatImp.v
@@ -172,6 +172,9 @@ Class parameters(varname: Type) := {
 
   ext_spec: ExtSpec;
 }.
+Module word.
+  Notation of_Z := (Word.Interface.word.of_Z(word:=word)).
+End word.
 
 Module ext_spec.
   Class ok(varname: Type){p: parameters varname}: Prop := {

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -70,6 +70,10 @@ Class parameters := {
              mem -> String.string -> list word -> (mem -> list word -> Prop) -> Prop;
 }.
 
+Module word.
+  Notation of_Z := (Word.Interface.word.of_Z(word:=word)).
+End word.
+
 Arguments Z.mul: simpl never.
 Arguments Z.add: simpl never.
 Arguments Z.of_nat: simpl never.
@@ -824,7 +828,7 @@ Section FlatToRiscv1.
              rewrite Z2Nat.id in F. 2: {
                pose proof word.unsigned_range (word.sub k addr). blia.
              }
-             apply (f_equal (word.of_Z(word:=word))) in F.
+             apply (f_equal word.of_Z) in F.
              simpl_param_projections.
              rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
              rewrite <- add_0_r at 1. change (Z.of_nat 0) with 0 in F. rewrite <- F.
@@ -834,7 +838,7 @@ Section FlatToRiscv1.
              assert (Z.of_nat (S n) < 2 ^ width) by blia.
              apply (f_equal Z.of_nat) in F.
              rewrite Z2Nat.id in F by blia.
-             apply (f_equal (word.of_Z(word:=word))) in F.
+             apply (f_equal word.of_Z) in F.
              simpl_param_projections.
              rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
              ring_simplify (word.sub k (word.add addr (word.of_Z 1))).
@@ -864,7 +868,7 @@ Section FlatToRiscv1.
     - destr (Z.eqb (word.unsigned addr mod 4) 0).
       + destruct (program_compile_byte_list_array (b0 :: bs) addr eq_refl E) as [padding P].
         exists (array ptsto (word.of_Z 1)
-            (word.add addr (word.of_Z (word.unsigned (word.of_Z(word:=word) 1) * Z.of_nat (length (b0 :: bs))))) padding).
+            (word.add addr (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat (length (b0 :: bs))))) padding).
         rewrite P.
         rewrite array_append.
         rewrite sep_comm.

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -663,8 +663,7 @@ Section FlatToRiscv1.
     rewrite map.putmany_of_tuple_to_putmany.
     rewrite (map.putmany_of_tuple_to_putmany n m1 ks vs).
     apply map.disjoint_putmany_commutes.
-    pose proof map.getmany_of_tuple_to_sub_domain as P.
-    specialize P with (1 := E).
+    pose proof map.getmany_of_tuple_to_sub_domain _ _ _ _ E as P.
     apply map.sub_domain_value_indep with (vs2 := vs) in P.
     set (mp := (map.putmany_of_tuple ks vs map.empty)) in *.
     apply map.disjoint_comm.
@@ -676,7 +675,7 @@ Section FlatToRiscv1.
       map.same_domain m m'.
   Proof.
     intros. unfold store_bytes, load_bytes, unchecked_store_bytes in *. simp.
-    eauto using map.putmany_of_tuple_preserves_domain.
+    eapply map.putmany_of_tuple_preserves_domain; eauto.
   Qed.
 
   Lemma seplog_subst_eq{A B R: mem -> Prop} {mL mH: mem}
@@ -794,7 +793,7 @@ Section FlatToRiscv1.
       wcancel.
   Qed.
 
-  Lemma array_to_of_list_word_at: forall l addr m,
+  Lemma array_to_of_list_word_at: forall l addr (m: mem),
       array ptsto (word.of_Z 1) addr l m ->
       m = OfListWord.map.of_list_word_at addr l.
   Proof.
@@ -825,7 +824,7 @@ Section FlatToRiscv1.
              rewrite Z2Nat.id in F. 2: {
                pose proof word.unsigned_range (word.sub k addr). blia.
              }
-             apply (f_equal word.of_Z) in F.
+             apply (f_equal (word.of_Z(word:=word))) in F.
              simpl_param_projections.
              rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
              rewrite <- add_0_r at 1. change (Z.of_nat 0) with 0 in F. rewrite <- F.
@@ -835,7 +834,7 @@ Section FlatToRiscv1.
              assert (Z.of_nat (S n) < 2 ^ width) by blia.
              apply (f_equal Z.of_nat) in F.
              rewrite Z2Nat.id in F by blia.
-             apply (f_equal word.of_Z) in F.
+             apply (f_equal (word.of_Z(word:=word))) in F.
              simpl_param_projections.
              rewrite (word.of_Z_unsigned (word.sub k addr)) in F.
              ring_simplify (word.sub k (word.add addr (word.of_Z 1))).
@@ -865,7 +864,7 @@ Section FlatToRiscv1.
     - destr (Z.eqb (word.unsigned addr mod 4) 0).
       + destruct (program_compile_byte_list_array (b0 :: bs) addr eq_refl E) as [padding P].
         exists (array ptsto (word.of_Z 1)
-            (word.add addr (word.of_Z (word.unsigned (word.of_Z 1) * Z.of_nat (length (b0 :: bs))))) padding).
+            (word.add addr (word.of_Z (word.unsigned (word.of_Z(word:=word) 1) * Z.of_nat (length (b0 :: bs))))) padding).
         rewrite P.
         rewrite array_append.
         rewrite sep_comm.
@@ -887,7 +886,7 @@ Section FlatToRiscv1.
         apply invert_ptsto_instr in C. apply proj2 in C. congruence.
   Qed.
 
-  Lemma shift_load_bytes_in_of_list_word: forall l addr n t index,
+  Lemma shift_load_bytes_in_of_list_word: forall l (addr: word) n t index,
       Memory.load_bytes n (OfListWord.map.of_list_word l) index = Some t ->
       Memory.load_bytes n (OfListWord.map.of_list_word_at addr l) (word.add addr index) = Some t.
   Proof.
@@ -911,10 +910,7 @@ Section FlatToRiscv1.
   Proof.
     intros *. intros L M.
     destruct (program_compile_byte_list table addr) as [Padding P].
-    pose proof Proper_sep_impl1 as A.
-    unfold Morphisms.Proper, Morphisms.respectful in A.
-    specialize A with (1 := P). specialize (A R R). apply A in M. 2: reflexivity.
-    clear A P.
+    apply (Proper_sep_impl1 _ _ P R R) in M; [|reflexivity]; clear P.
     unfold Memory.load, Memory.load_Z in *. simp.
     eapply shift_load_bytes_in_of_list_word in E0.
     pose proof @subst_load_bytes_for_eq as P. cbv zeta in P.

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -1370,7 +1370,7 @@ Section Proofs.
     - idtac "Case compile_stmt_correct/SStore".
       simpl_MetricRiscvMachine_get_set.
       unfold Memory.store, Memory.store_Z in *.
-      change Memory.store_bytes with Platform.Memory.store_bytes in *.
+      change Memory.store_bytes with (Platform.Memory.store_bytes(word:=word)) in *.
       match goal with
       | H: Platform.Memory.store_bytes _ _ _ _ = _ |- _ =>
         unshelve epose proof (@store_bytes_frame _ _ _ _ _ _ _ _ _ H _) as P; cycle 2
@@ -1549,7 +1549,7 @@ Section Proofs.
           eexists (stack_trash ++ returned_words). split. 2: {
             seprewrite_in QQ Q.
             replace (Datatypes.length remaining_stack) with (Datatypes.length stack_trash) by blia.
-            assert (!bytes_per_word * !(n / bytes_per_word) = !n) as DivExact. {
+            assert (!bytes_per_word * !(n / bytes_per_word) = !n :> word) as DivExact. {
               ParamRecords.simpl_param_projections.
               rewrite <- (word.ring_morph_mul (bytes_per_word) (n / bytes_per_word)).
               rewrite <- Z_div_exact_2.

--- a/compiler/src/compiler/FlattenExpr.v
+++ b/compiler/src/compiler/FlattenExpr.v
@@ -467,7 +467,7 @@ Section FlattenExpr1.
     reflexivity.
   Qed.
 
-  Lemma one_ne_zero: word.of_Z 1 <> word.of_Z 0.
+  Lemma one_ne_zero: word.of_Z 1 <> word.of_Z 0 :> word.
   Proof.
     apply unsigned_ne.
     rewrite! word.unsigned_of_Z. unfold word.wrap.
@@ -476,7 +476,7 @@ Section FlattenExpr1.
   Qed.
 
   Lemma bool_to_word_to_bool_id: forall (b: bool),
-      negb (word.eqb (if b then word.of_Z 1 else word.of_Z 0) (word.of_Z 0)) = b.
+      negb (word.eqb (if b then word.of_Z 1 else word.of_Z (width:=width) 0) (word.of_Z 0)) = b.
   Proof.
     intro b. unfold negb.
     destruct_one_match; destruct_one_match_hyp; try reflexivity.

--- a/compiler/src/compiler/FlattenExpr.v
+++ b/compiler/src/compiler/FlattenExpr.v
@@ -476,7 +476,7 @@ Section FlattenExpr1.
   Qed.
 
   Lemma bool_to_word_to_bool_id: forall (b: bool),
-      negb (word.eqb (if b then word.of_Z 1 else word.of_Z (width:=width) 0) (word.of_Z 0)) = b.
+      negb (word.eqb (if b then word.of_Z 1 else word.of_Z 0) (word.of_Z 0)) = b.
   Proof.
     intro b. unfold negb.
     destruct_one_match; destruct_one_match_hyp; try reflexivity.

--- a/compiler/src/compiler/GoFlatToRiscv.v
+++ b/compiler/src/compiler/GoFlatToRiscv.v
@@ -338,7 +338,7 @@ Section Go.
         simpl. right. assumption.
   Qed.
 
-  Lemma ptsto_bytes_putmany_of_tuple_empty: forall n addr vs,
+  Lemma ptsto_bytes_putmany_of_tuple_empty: forall n (addr: word) vs,
       Z.of_nat n < 2 ^ width ->
       ptsto_bytes n addr vs (map.putmany_of_tuple (footprint addr n) vs map.empty).
   Proof.
@@ -407,7 +407,7 @@ Section Go.
     destruct width_cases as [E | E]; rewrite E; cbv; discriminate.
   Qed.
 
-  Lemma ptsto_subset_to_isXAddr1: forall a v xAddrs,
+  Lemma ptsto_subset_to_isXAddr1: forall (a : word) (v : Init.Byte.byte) xAddrs,
       subset (footpr (ptsto a v)) (of_list xAddrs) ->
       isXAddr1 a xAddrs.
   Proof.

--- a/compiler/src/compiler/PipelineWithRename.v
+++ b/compiler/src/compiler/PipelineWithRename.v
@@ -328,7 +328,7 @@ Section Pipeline1.
   Local Instance  EqDecider_FlatImp__word_eq : EqDecider FlatImp__word_eq.
   Proof. eapply word.eqb_spec. Unshelve. all: exact word_ok. Qed.
 
-  Lemma mem_available_to_exists: forall start pastend m P,
+  Lemma mem_available_to_exists: forall start pastend (m: mem) P,
       (mem_available start pastend * P)%sep m ->
       exists anybytes,
         Z.of_nat (List.length anybytes) = word.unsigned (word.sub pastend start) /\
@@ -341,7 +341,7 @@ Section Pipeline1.
     eauto.
   Qed.
 
-  Definition mem_to_available: forall start pastend m P anybytes,
+  Definition mem_to_available: forall start pastend (m: mem) P anybytes,
      Z.of_nat (List.length anybytes) = word.unsigned (word.sub pastend start) ->
      (ptsto_bytes start anybytes * P)%sep m ->
      (mem_available start pastend * P)%sep m.

--- a/compiler/src/compiler/RiscvWordProperties.v
+++ b/compiler/src/compiler/RiscvWordProperties.v
@@ -6,6 +6,7 @@ Module word.
 
   Section RiscvWord.
     Context {width: Z} {word: word.word width}.
+    Implicit Types x y z : word.
 
     (* TODO maybe we can put more fundamental axioms here, and turn the axioms below into lemmas *)
     Class riscv_ok: Prop := {

--- a/compiler/src/compiler/RunInstruction.v
+++ b/compiler/src/compiler/RunInstruction.v
@@ -359,7 +359,7 @@ Section Run.
 
   Lemma iff1_emp: forall P Q,
       (P <-> Q) ->
-      iff1 (emp P) (emp Q).
+      @iff1 mem (emp P) (emp Q).
   Proof. unfold iff1, emp. clear. firstorder idtac. Qed.
 
   Lemma removeXAddr_diff: forall a1 a2 xaddrs,
@@ -385,7 +385,7 @@ Section Run.
     eassumption.
   Qed.
 
-  Lemma sep_ptsto_to_addr_neq: forall a1 v1 a2 v2 m R,
+  Lemma sep_ptsto_to_addr_neq: forall a1 v1 a2 v2 (m : mem) R,
       (ptsto a1 v1 * ptsto a2 v2 * R)%sep m ->
       a1 <> a2.
   Proof.

--- a/compiler/src/compiler/SeparationLogic.v
+++ b/compiler/src/compiler/SeparationLogic.v
@@ -79,7 +79,7 @@ Section ptstos.
     ecancel_assumption.
   Qed.
 
-  Lemma cast_word_array_to_bytes bs addr : iff1
+  Lemma cast_word_array_to_bytes bs (addr : word) : iff1
     (array ptsto_word (word.of_Z bytes_per_word) addr bs)
     (array ptsto (word.of_Z 1) addr (flat_map (fun x =>
        HList.tuple.to_list (LittleEndian.split (Z.to_nat bytes_per_word) (word.unsigned x)))
@@ -191,7 +191,7 @@ Section ptstos.
 
   Lemma byte_list_to_word_list_array {word_ok: word.ok word}: forall bytes,
     Z.of_nat (length bytes) mod bytes_per_word = 0 ->
-    exists word_list,
+    exists word_list : list word,
       Z.of_nat (Datatypes.length word_list) =
       Z.of_nat (Datatypes.length bytes) / bytes_per_word /\
     forall p,

--- a/compiler/src/compiler/Spilling.v
+++ b/compiler/src/compiler/Spilling.v
@@ -45,6 +45,7 @@ Module map.
   Section MAP.
     Context {key value} {map : map.map key value}.
     Context {ok : map.ok map} {key_eqb: key -> key -> bool} {key_eq_dec : EqDecider key_eqb}.
+    Implicit Types (k : key) (v : value) (x y z m : map).
 
     (* Note: there's already one in coqutil that requires disjointness *)
     Lemma putmany_assoc x y z : map.putmany x (map.putmany y z) = map.putmany (map.putmany x y) z.
@@ -560,7 +561,7 @@ Section Spilling.
         length newwords = length oldwords.
   Admitted.
 
-  Lemma store_bytes_sep_hi2lo: forall mH mL R a n v_old v,
+  Lemma store_bytes_sep_hi2lo: forall (mH mL : mem) R a n v_old v,
       Memory.load_bytes n mH a = Some v_old ->
       (eq mH * R)%sep mL ->
       (eq (Memory.unchecked_store_bytes n mH a v) * R)%sep (Memory.unchecked_store_bytes n mL a v).
@@ -1008,7 +1009,7 @@ Section Spilling.
       exec e (s1;; (s2;; s3)) t m l mc post.
   Proof. intros. simp. eauto 10 using exec.seq. Qed.
 
-  Lemma get_arg_reg_1: forall l l2 y y' z z',
+  Lemma get_arg_reg_1: forall l l2 y y' (z : Z) (z' : word),
       fp < y ->
       fp < z ->
       map.get l y = Some y' ->
@@ -1086,7 +1087,7 @@ Section Spilling.
     let sz := Z.to_nat (@Memory.bytes_per_word width) in
     List.map word.of_Z (byte_list_to_Z_list sz (length bs / sz)%nat bs).
 
-  Lemma littleendian_head_to_Z: forall n l addr,
+  Lemma littleendian_head_to_Z: forall n l (addr : word),
       iff1 (littleendian n addr (head_to_Z n l))
            (array ptsto (word.of_Z 1) addr (List__firstn_default n l Byte.x00)).
   Proof.
@@ -1095,7 +1096,7 @@ Section Spilling.
     reflexivity.
   Qed.
 
-  Lemma scalar_head_to_Z: forall l addr,
+  Lemma scalar_head_to_Z: forall l (addr : word),
       iff1 (scalar addr (word.of_Z (head_to_Z (Z.to_nat bytes_per_word) l)))
            (array ptsto (word.of_Z 1) addr (List__firstn_default (Z.to_nat bytes_per_word) l Byte.x00)).
   Proof.

--- a/compiler/src/compiler/SpillingMapGoals.v
+++ b/compiler/src/compiler/SpillingMapGoals.v
@@ -6,6 +6,7 @@ Require Import coqutil.Map.Interface coqutil.Map.Properties.
 
 Section LEMMAS.
   Context {K V: Type} {map: map.map K V} {ok: map.ok map}.
+  Implicit Types (k : K) (v : V) (m : map).
 
   Axiom map__split_spec: forall (M A B: map),
       map.split M A B <-> forall k,

--- a/compiler/src/compiler/SpillingUniqueSepLog.v
+++ b/compiler/src/compiler/SpillingUniqueSepLog.v
@@ -492,7 +492,7 @@ Section Spilling.
     intros. eapply exec.seq. 1: eassumption. simpl. clear. auto.
   Qed.
 
-  Lemma load_putmany_l: forall m1 m2 sz a v,
+  Lemma load_putmany_l: forall m1 m2 sz a (v : word),
       Memory.load sz m1 a = Some v ->
       disjoint (map.dom m1) (map.dom m2) ->
       Memory.load sz (map.putmany m1 m2) a = Some v.

--- a/compiler/src/compiler/ToplevelLoop.v
+++ b/compiler/src/compiler/ToplevelLoop.v
@@ -180,7 +180,7 @@ Section Pipeline1.
 
   Lemma signed_of_Z_small: forall c,
       - 2 ^ 31 <= c < 2 ^ 31 ->
-      word.signed (word.of_Z c) = c.
+      word.signed (word.of_Z (width:=FlatImp.width) c) = c.
   Proof.
     clear -h.
     simpl.

--- a/compiler/src/compiler/ToplevelLoop.v
+++ b/compiler/src/compiler/ToplevelLoop.v
@@ -185,13 +185,8 @@ Section Pipeline1.
     clear -h.
     simpl.
     intros.
-    rewrite word.signed_of_Z.
-    unfold word.swrap.
-    destruct width_cases as [E | E]; rewrite E; change (32 - 1) with 31; change (64 - 1) with 63;
-      repeat match goal with
-             | |- context[2 ^ ?x] => let x' := eval cbv in (2 ^ x) in change (2 ^ x) with x' in *
-             end;
-      clear E; Z.div_mod_to_equations; blia.
+    eapply word.signed_of_Z_nowrap.
+    case width_cases as [E | E]; rewrite E; Lia.lia.
   Qed.
 
   Lemma establish_ll_inv: forall (initial: MetricRiscvMachine),

--- a/compiler/src/compiler/UniqueSepLog.v
+++ b/compiler/src/compiler/UniqueSepLog.v
@@ -116,6 +116,7 @@ Axiom TODO: False.
 Module map. Section __.
   Context {key value} {map : map.map key value} {ok: map.ok map}.
   Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
+  Implicit Types (k : key) (v : value) (m : map).
 
   Lemma put_comm: forall k1 k2 v1 v2 m,
       k1 <> k2 ->

--- a/compiler/src/compilerExamples/SimpleInvariant.v
+++ b/compiler/src/compilerExamples/SimpleInvariant.v
@@ -22,6 +22,7 @@ Require Import riscv.Utility.InstructionCoercions.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Monads.
 Require Import riscv.Spec.Machine.
+Import Utility.
 
 Arguments Jal (_)%Z (_)%Z. (* needed when inside a (_)%sep *)
 

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -238,8 +238,8 @@ Section Connect.
 
   Lemma riscvMemInit_to_seplog_aux: forall len from,
       Z.of_nat from + Z.of_nat len <= 2 ^ memSizeLg ->
-      PipelineWithRename.ptsto_bytes (width:=width)
-        (word.of_Z (Z.of_nat from))
+      PipelineWithRename.ptsto_bytes
+        (word.of_Z (word:=Utility.word) (Z.of_nat from))
         (map (get_kamiMemInit memInit) (seq from len))
         (map.of_list (map
           (fun i => (word.of_Z (BinIntDef.Z.of_nat i),
@@ -251,8 +251,6 @@ Section Connect.
     - cbv. auto.
     - unfold PipelineWithRename.ptsto_bytes, riscvMemInit_values in *.
       cbn [seq map array map.of_list].
-      (* PARAMRECORDS-instance *)
-      change (KamiWord.word 32) with (@Utility.word Words32).
       match goal with
       | |- context [map.put ?m ?k ?v] => pose proof map.put_putmany_commute k v m map.empty as P
       end.
@@ -264,8 +262,6 @@ Section Connect.
       ssplit; cycle 1.
       + specialize (IHlen (S from)).
         replace (Z.of_nat (S from)) with (Z.of_nat from + 1) in IHlen by blia.
-        (* PARAMRECORDS-instance *)
-        change (KamiWord.word 32) with (@Utility.word Words32) in IHlen.
         rewrite word.ring_morph_add in IHlen.
         apply IHlen. blia.
       + unfold ptsto. reflexivity.

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -238,7 +238,7 @@ Section Connect.
 
   Lemma riscvMemInit_to_seplog_aux: forall len from,
       Z.of_nat from + Z.of_nat len <= 2 ^ memSizeLg ->
-      PipelineWithRename.ptsto_bytes
+      PipelineWithRename.ptsto_bytes (width:=width)
         (word.of_Z (Z.of_nat from))
         (map (get_kamiMemInit memInit) (seq from len))
         (map.of_list (map

--- a/processor/src/processor/Consistency.v
+++ b/processor/src/processor/Consistency.v
@@ -86,11 +86,10 @@ Section FetchOk.
     alignedXAddrsRange 0 instrMemSize.
 
   Lemma AddrAligned_plus4:
-    forall rpc,
+    forall rpc: KamiWord.word _,
       AddrAligned rpc ->
-      AddrAligned (word.add (width:=width) rpc (word.of_Z 4)).
+      AddrAligned (word.add rpc (word.of_Z 4)).
   Proof.
-    Set Printing Implicit.
     cbv [AddrAligned word.add word WordsKami wordW KamiWord.word].
     intros.
     rewrite <-H.
@@ -191,7 +190,7 @@ Section FetchOk.
       isXAddr4 rpc kamiXAddrs ->
       exists rinst : HList.tuple byte 4,
         map.getmany_of_tuple rmem (Memory.footprint rpc 4) = Some rinst /\
-        combine 4 rinst = kunsigned (width:= 32) (SC.combineBytes 4 rpc kmem).
+        combine 4 rinst = kunsigned (SC.combineBytes 4 rpc kmem : kword 32).
   Proof.
     intros.
 
@@ -342,11 +341,11 @@ Section DecExecOk.
       forall w z,
         Z.of_N (wordToN w) = z ->
         krf w =
-        (if Z.eq_dec z 0 then word.of_Z (width:=width) 0
+        (if Z.eq_dec z 0 then kofZ 0
          else
            match map.get rrf z with
            | Some x => x
-           | None => word.of_Z (width:=width) 0
+           | None => kofZ 0
            end).
   Proof.
     intros.

--- a/processor/src/processor/Consistency.v
+++ b/processor/src/processor/Consistency.v
@@ -88,8 +88,9 @@ Section FetchOk.
   Lemma AddrAligned_plus4:
     forall rpc,
       AddrAligned rpc ->
-      AddrAligned (word.add rpc (word.of_Z 4)).
+      AddrAligned (word.add (width:=width) rpc (word.of_Z 4)).
   Proof.
+    Set Printing Implicit.
     cbv [AddrAligned word.add word WordsKami wordW KamiWord.word].
     intros.
     rewrite <-H.
@@ -341,11 +342,11 @@ Section DecExecOk.
       forall w z,
         Z.of_N (wordToN w) = z ->
         krf w =
-        (if Z.eq_dec z 0 then word.of_Z 0
+        (if Z.eq_dec z 0 then word.of_Z (width:=width) 0
          else
            match map.get rrf z with
            | Some x => x
-           | None => word.of_Z 0
+           | None => word.of_Z (width:=width) 0
            end).
   Proof.
     intros.

--- a/processor/src/processor/KamiRiscv.v
+++ b/processor/src/processor/KamiRiscv.v
@@ -336,9 +336,9 @@ Section Equiv.
     all: discriminate.
   Qed.
 
-  Definition riscvMemInit := map.of_list (List.map
+  Definition riscvMemInit : mem := map.of_list (List.map
     (fun i : nat =>
-      (word.of_Z (width:=width) (Z.of_nat i),
+      (word.of_Z (Z.of_nat i),
        byte.of_Z (uwordToZ (evalConstT kamiMemInit $i))))
     (seq 0 (2 ^ Z.to_nat memSizeLg))).
 

--- a/processor/src/processor/KamiRiscv.v
+++ b/processor/src/processor/KamiRiscv.v
@@ -338,7 +338,7 @@ Section Equiv.
 
   Definition riscvMemInit := map.of_list (List.map
     (fun i : nat =>
-      (word.of_Z (Z.of_nat i),
+      (word.of_Z (width:=width) (Z.of_nat i),
        byte.of_Z (uwordToZ (evalConstT kamiMemInit $i))))
     (seq 0 (2 ^ Z.to_nat memSizeLg))).
 

--- a/processor/src/processor/KamiRiscvStep.v
+++ b/processor/src/processor/KamiRiscvStep.v
@@ -40,6 +40,7 @@ Local Open Scope Z_scope.
 (** Consistency between the Kami word and the Z-based word *)
 Section WordZ.
   Local Hint Resolve (@KamiWord.WordsKami width width_cases): typeclass_instances.
+  Local Hint Mode word.word - : typeclass_instances.
 
   Lemma bitSlice_range_ex:
     forall z n m,
@@ -487,6 +488,7 @@ End WordZ.
 
 Section Equiv.
   Local Hint Resolve (@KamiWord.WordsKami width width_cases): typeclass_instances.
+  Local Hint Mode word.word - : typeclass_instances.
 
   Context {Registers: map.map Z word}
           {mem: map.map word byte}.


### PR DESCRIPTION
This would disable type class inference of map and word implementations from guessing the word width, map key type, and map value type. This means that unspecified words or maps fail to typecheck, requiring just enough annotation to reveal how large words or what type of maps are in question. I prepared this change after an annoying debugging session ultimately caused by inference of a locals-to-words map where I had meant to use universally quantified keys. If this is merged, I think 8eb47c3f3101482a5bc17baad80a17fe7116807f could be reverted as well, and a word instance for bytes could be re-added.

The main downside is that several files currently relied on the TC-inferred word instance for `word.of_Z` in a context where the return type was not clear (e.g., `word.unsigned (word.of_Z _)`). I think the ideal solution would look something like `Semantics.word.(of_Z)`, or the equivalent when `Semantics` is imported, but I don't know how to achieve that. There is also annoyance from `replace` not constraining the two sides of the implied equality to have the same type, and a generic fix should be possible for that.

The effect of this patch can be disabled locally using `Local Hint Mode word.word - : typeclass_instances` and `Local Hint Mode map.map - - : typeclass_instances`.


