### PR TITLE
Add ProgramLogic.Coercions

### DIFF
--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -9,6 +9,20 @@ Require bedrock2.string2ident.
 Definition spec_of (procname:String.string) := list (String.string * (list String.string * list String.string * Syntax.cmd.cmd)) -> Prop.
 Existing Class spec_of.
 
+Module Import Coercions.
+  Import Map.Interface Word.Interface BinInt.
+  Coercion Z.of_nat : nat >-> Z.
+  Coercion word.unsigned : word.rep >-> Z.
+
+  Definition sepclause_of_map {key value map} (m : @map.rep key value map)
+    : map.rep -> Prop := Logic.eq m.
+  Coercion sepclause_of_map : Interface.map.rep >-> Funclass.
+End Coercions.
+
+Goal True.
+  assert_succeeds epose (fun k v M (m : @Interface.map.rep k v M) => m _).
+Abort.
+
 Section bindcmd.
   Context {T : Type}.
   Fixpoint bindcmd (c : Syntax.cmd) (k : Syntax.cmd -> T) {struct c} : T :=

--- a/bedrock2/src/bedrock2Examples/memmove.v
+++ b/bedrock2/src/bedrock2Examples/memmove.v
@@ -9,20 +9,12 @@ Require Import coqutil.Word.Interface coqutil.Map.Interface bedrock2.Map.Separat
 (*Require Import bedrock2.ptsto_bytes.*)
 Require Import coqutil.Map.OfListWord.
 Local Notation "xs $@ a" := (map.of_list_word_at a xs) (at level 10, format "xs $@ a").
+Local Notation "m =* P" := ((P%sep) m) (at level 70, only parsing) (* experiment*).
 
 Section WithParameters.
   Context {p : Semantics.parameters}.
-  Local Coercion Z.of_nat : nat >-> Z.
-  Local Coercion word.unsigned : word.rep >-> Z.
+  Import ProgramLogic.Coercions.
 
-  Local Hint Mode map.map + + : typeclass_instances.
-  Let sepclause {key value} {map : map.map key value} := map -> Prop.
-  Local Coercion map_eq {key value map} (m : @map.rep key value map)
-    : sepclause := Logic.eq m.
-  Local Definition sep {key value} {map : map.map key value}
-    : sepclause -> sepclause -> sepclause := sep (map:=map).
-  Local Infix "*" := sep : sep_scope.
-  Local Notation "m =* P" := ((P%sep:sepclause) m) (at level 70, only parsing).
 
   Instance spec_of_memmove : spec_of "memmove" :=
     fnspec! "memmove" dst src (n : Semantics.word) / d s R Rs,


### PR DESCRIPTION
```coq
nat >-> Z
word >-> Z
map >-> (map->Prop) (* experimental *)
```

The last one is kinda neat, but will it misfire badly too often? I tried making `sep` take a wrapped version of `map->Prop` as an argument, and that lead to a lot of changes and some unclear design decisions (e.g., what to do with `Lift1Prop` combinators?).