### PR TITLE
Adapt to coq/coq#13837 ("apply with" does not rename arguments)

### DIFF
--- a/compiler/src/compiler/ExprImp.v
+++ b/compiler/src/compiler/ExprImp.v
@@ -533,15 +533,15 @@ Section ExprImp2.
     - eapply exec.if_false; try eassumption.
       eapply weaken_exec; [eassumption|].
       simpl; intros. map_solver locals_ok.
-    - eapply exec.seq with
-          (mid0 := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars c1) l').
+    - eapply @exec.seq with
+          (mid := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars c1) l').
       + eapply intersect_exec; eassumption.
       + simpl. intros *. intros [? ?].
         eapply weaken_exec; [eapply H1; eauto|].
         simpl; intros.
         map_solver locals_ok.
-    - eapply exec.while_true with
-          (mid0 := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars c) l');
+    - eapply @exec.while_true with
+          (mid := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars c) l');
         try eassumption.
       + eapply intersect_exec; eassumption.
       + intros *. intros [? ?]. simpl in *.

--- a/compiler/src/compiler/FlatImp.v
+++ b/compiler/src/compiler/FlatImp.v
@@ -649,10 +649,10 @@ Section FlatImp2.
     - eapply exec.if_false; try eassumption.
       eapply exec.weaken; [eassumption|].
       simpl; intros. map_solver locals_ok.
-    - eapply exec.loop with
-          (mid3 := fun t' m' l' mc' => mid1 t' m' l' mc' /\
+    - eapply @exec.loop with
+          (mid1 := fun t' m' l' mc' => mid1 t' m' l' mc' /\
                                    map.only_differ l (modVars body1) l')
-          (mid4 := fun t' m' l' mc' => mid2 t' m' l' mc' /\
+          (mid2 := fun t' m' l' mc' => mid2 t' m' l' mc' /\
                                    map.only_differ l (modVars (SLoop body1 cond body2)) l').
       + eapply exec.intersect; eassumption.
       + intros. simp. eauto.
@@ -666,8 +666,8 @@ Section FlatImp2.
         eapply exec.weaken.
         * eapply H5; eassumption.
         * simpl. intros. map_solver locals_ok.
-    - eapply exec.seq with
-          (mid0 := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars s1) l').
+    - eapply @exec.seq with
+          (mid := fun t' m' l' mc' => mid t' m' l' mc' /\ map.only_differ l (modVars s1) l').
       + eapply exec.intersect; eassumption.
       + simpl; intros. simp.
         eapply exec.weaken; [eapply H1; eauto|].

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -455,7 +455,8 @@ Section Proofs.
 
       (* put arguments on stack *)
       eapply runsTo_trans. {
-        eapply save_regs_correct with (vars := args) (p_sp0 := p_sp)
+        rename p_sp into p_sp0.
+        eapply save_regs_correct with (vars := args) (p_sp := p_sp0)
          (offset := (- Memory.bytes_per_word (bitwidth iset) * Z.of_nat (List.length args))%Z); simpl; cycle -4.
         - eapply rearrange_footpr_subset; [ eassumption | wwcancel ].
         - wcancel_assumption.
@@ -889,10 +890,10 @@ Section Proofs.
 
     (* load result values from stack *)
     eapply runsTo_trans. {
-      eapply load_regs_correct with
+      eapply @load_regs_correct with
           (vars := binds) (values := retvs)
           (offset := (- bytes_per_word * Z.of_nat (List.length args + List.length binds))%Z)
-          (p_sp0 := p_sp);
+          (p_sp := p_sp);
         simpl; cycle -4; try assumption.
       - safe_sidecond.
       - wcancel_assumption.
@@ -1509,7 +1510,7 @@ Section Proofs.
         { match goal with
           | |- ?G => let t := type of Ab in replace G with t; [exact Ab|f_equal]
           end.
-          rewrite length_flat_map with (n0 := Z.to_nat bytes_per_word).
+          rewrite @length_flat_map with (n := Z.to_nat bytes_per_word).
           - simpl_addrs. rewrite !Z2Nat.id by blia. rewrite <- BPW. rewrite <- Z_div_exact_2; blia.
           - clear. intros. rewrite HList.tuple.length_to_list. reflexivity.
         }

--- a/compiler/src/compiler/Softmul.v
+++ b/compiler/src/compiler/Softmul.v
@@ -520,7 +520,7 @@ Section Riscv.
       cbn in V; try (intuition congruence).
     - (* IInstruction *)
       subst.
-      eapply runsToStep with (midset0 := fun midL => exists midH, related midH midL /\ midset midH).
+      eapply @runsToStep with (midset := fun midL => exists midH, related midH midL /\ midset midH).
       + eapply build_fetch_one_instr.
         { etransitivity. 2: exact H2p6p3.
           reify_goal.
@@ -643,7 +643,7 @@ Section Riscv.
         case TODO.
     - (* CSRInstruction *)
       subst.
-      eapply runsToStep with (midset0 := fun midL => exists midH, related midH midL /\ midset midH).
+      eapply @runsToStep with (midset := fun midL => exists midH, related midH midL /\ midset midH).
       + eapply build_fetch_one_instr.
         { etransitivity. 2: exact H2p6p3.
           reify_goal.

--- a/compiler/src/compiler/load_save_regs_correct.v
+++ b/compiler/src/compiler/load_save_regs_correct.v
@@ -70,7 +70,7 @@ Section Proofs.
         rewrite bitwidth_matches. reflexivity.
       }
       eapply runsToNonDet.runsToStep. {
-        eapply run_store_word with (Rexec0 := (program iset (word.add (getPc initial) (word.of_Z 4))
+        eapply @run_store_word with (Rexec := (program iset (word.add (getPc initial) (word.of_Z 4))
             (save_regs iset vars (offset + bytes_per_word)) * Rexec)%sep); cycle -3;
           [> sidecondition | use_sep_assumption; cbn; ecancel | sidecondition.. ].
       }

--- a/end2end/src/end2end/End2EndPipeline.v
+++ b/end2end/src/end2end/End2EndPipeline.v
@@ -513,7 +513,7 @@ Section Connect.
         end.
       + reflexivity.
       + simpl. split.
-        * apply riscv_init_memory_undef_on_MMIO with (instrMemSizeLg0:= instrMemSizeLg).
+        * apply @riscv_init_memory_undef_on_MMIO with (instrMemSizeLg:= instrMemSizeLg).
           { apply instrMemSizeLg_bounds. }
           { apply Hkmem. }
           { cbv [KamiProc.width]; blia. }


### PR DESCRIPTION
Should be backwards compatible.