### PR TITLE
Ecancel impl

### DIFF
--- a/bedrock2/src/bedrock2/Map/SeparationLogic.v
+++ b/bedrock2/src/bedrock2/Map/SeparationLogic.v
@@ -479,7 +479,7 @@ Ltac ecancel_step_by_implication :=
       let LHS := lazymatch goal with |- Lift1Prop.impl1 (seps ?LHS) _ => LHS end in
       let i := find_implication LHS y in (* <-- multi-success! *)
       (*TODO: nocore?*)
-      cancel_seps_at_indices_by_implication i j; [solve [auto 1 with ecancel_impl]|].
+      cancel_seps_at_indices_by_implication i j; [solve [auto 1 with nocore ecancel_impl]|].
 
 Ltac ecancel_done :=
   cbn [seps];


### PR DESCRIPTION
Generalizes `ecancel` to work on `impl1` in addition to `iff1` and modifies `ecancel_assumption` to use the new code path. Currently leads to some performance regression, on the order of 10% for the full development on my machine.