### PR TITLE
replace LittleEndian with LittleEndianList in bedrock2/

### DIFF
--- a/bedrock2/src/bedrock2/Memory.v
+++ b/bedrock2/src/bedrock2/Memory.v
@@ -6,7 +6,7 @@ Require Import coqutil.Decidable.
 Require Import coqutil.Datatypes.PrimitivePair coqutil.Datatypes.HList coqutil.Datatypes.List.
 Require Import coqutil.Map.Interface coqutil.Map.Properties.
 Require Import coqutil.Tactics.Tactics coqutil.Datatypes.Option.
-Require Import BinIntDef coqutil.Word.Interface coqutil.Word.LittleEndian.
+Require Import BinIntDef coqutil.Word.Interface coqutil.Word.LittleEndianList.
 Require Import bedrock2.Notations bedrock2.Syntax.
 Require Import coqutil.Byte.
 Require Import coqutil.Map.OfListWord.
@@ -141,12 +141,12 @@ Section Memory.
 
   Definition load_Z(sz: access_size)(m: mem)(a: word): option Z :=
     match load_bytes (bytes_per sz) m a with
-    | Some bs => Some (LittleEndian.combine _ bs)
+    | Some bs => Some (LittleEndianList.le_combine (tuple.to_list bs))
     | None => None
     end.
 
   Definition store_Z(sz: access_size)(m: mem)(a: word)(v: Z): option mem :=
-    store_bytes (bytes_per sz) m a (LittleEndian.split _ v).
+    store_bytes _ m a (tuple.of_list (LittleEndianList.le_split (bytes_per sz) v)).
 
   Definition load(sz: access_size)(m: mem)(a: word): option word :=
     match load_Z sz m a with

--- a/bedrock2/src/bedrock2/NotationsCustomEntry.v
+++ b/bedrock2/src/bedrock2/NotationsCustomEntry.v
@@ -128,8 +128,10 @@ Notation "output! f args" :=  (interact nil f args) (in custom bedrock_cmd at le
 Notation "unpack! lhs = f args" :=  (call lhs f args) (in custom bedrock_cmd at level 0, lhs custom bedrock_call_lhs , f custom bedrock_ident, args custom bedrock_args ).
 Notation "( lhs ) = f args" :=  (call lhs f args) (in custom bedrock_cmd at level 0, lhs custom bedrock_call_lhs , f custom bedrock_ident, args custom bedrock_args ,
   format "'(' lhs ')'  =  f args").
-Notation "f args" :=  (call nil (ident_to_string! f) args) (in custom bedrock_cmd at level 0, f ident, args custom bedrock_args ,
-  format "f args").
+Notation "f args" :=  (call nil (ident_to_string! f) args) (in custom bedrock_cmd at level 0,
+  f ident, args custom bedrock_args, format "f args").
+Notation "$ f args" :=  (call nil f args) (in custom bedrock_cmd at level 0,
+  f constr at level 0, args custom bedrock_args, format "'$' f args").
 
 Declare Scope bedrock_tail.
 Delimit Scope bedrock_tail with bedrock_tail.
@@ -309,6 +311,8 @@ Module test.
       }
     }
   )).
+
+  epose bedrock_func_body:($"write" ($1, $"W", $1, $1, $1, $1)).
 
   epose bedrock_func_body:(
   stackalloc 64 as $"b";

--- a/bedrock2/src/bedrock2/Semantics.v
+++ b/bedrock2/src/bedrock2/Semantics.v
@@ -2,7 +2,7 @@ Require Import coqutil.sanity coqutil.Macros.subst coqutil.Macros.unique coqutil
 Require Import coqutil.Datatypes.PrimitivePair coqutil.Datatypes.HList.
 Require Import coqutil.Decidable.
 Require Import bedrock2.Notations bedrock2.Syntax coqutil.Map.Interface coqutil.Map.OfListWord.
-Require Import BinIntDef coqutil.Word.Interface coqutil.Word.LittleEndian coqutil.Word.Bitwidth.
+Require Import BinIntDef coqutil.Word.Interface coqutil.Word.Bitwidth.
 Require Import bedrock2.MetricLogging.
 Require Export bedrock2.Memory.
 

--- a/bedrock2/src/bedrock2Examples/FlatConstMem.v
+++ b/bedrock2/src/bedrock2Examples/FlatConstMem.v
@@ -354,19 +354,19 @@ Section WithParameters.
   End __.
 
   Lemma load_four_bytes_of_sep_at bs a R (m:mem) (Hsep: (eq(bs$@a)*R) m) (Hl : length bs = 4%nat) :
-    load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
+    load access_size.four m a = Some (word.of_Z (LittleEndianList.le_combine bs)).
   Proof.
     eapply Scalars.load_four_bytes_of_sep_at; try eassumption. reflexivity.
   Qed.
 
   Lemma uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ length bs = 4%nat) :
-    load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
+    load access_size.four m a = Some (word.of_Z (LittleEndianList.le_combine bs)).
   Proof. eapply Scalars.uncurried_load_four_bytes_of_sep_at; try eassumption. reflexivity. Qed.
 
   Lemma Z_uncurried_load_four_bytes_of_sep_at bs a R (m : mem)
     (H: (eq(bs$@a)*R) m /\ Z.of_nat (length bs) = 4) :
-    load access_size.four m a = Some (word.of_Z (LittleEndian.combine _ (HList.tuple.of_list bs))).
+    load access_size.four m a = Some (word.of_Z (LittleEndianList.le_combine bs)).
   Proof. eapply Scalars.Z_uncurried_load_four_bytes_of_sep_at; try eassumption. reflexivity. Qed.
 
   (*

--- a/bedrock2/src/bedrock2Examples/LAN9250.v
+++ b/bedrock2/src/bedrock2Examples/LAN9250.v
@@ -466,9 +466,9 @@ Section WithParameters.
       erewrite word.unsigned_of_Z in H11.
       exact H11. }
 
-    cbv [HList.tuple.of_list List.app].
+    cbv [List.app].
     repeat match goal with x := _ |- _ => subst x end.
-    cbv [LittleEndian.combine PrimitivePair.pair._1 PrimitivePair.pair._2].
+    cbv [LittleEndianList.le_combine].
     repeat rewrite ?word.unsigned_of_Z, word.unsigned_sru_nowrap by (rewrite word.unsigned_of_Z; exact eq_refl).
 
     try erewrite ?word.unsigned_of_Z.
@@ -754,7 +754,7 @@ Section WithParameters.
       change 255 with (Z.ones 8); rewrite Z.land_ones by blia.
       Z.div_mod_to_equations. blia. }
     repeat match goal with x := _ |- _ => subst x end.
-    cbv [LittleEndian.combine HList.tuple.of_list PrimitivePair.pair._1 PrimitivePair.pair._2].
+    cbv [LittleEndianList.le_combine].
 
     repeat rewrite ?Properties.word.unsigned_or_nowrap, <-?Z.lor_assoc by (rewrite ?word.unsigned_of_Z; exact eq_refl).
     change (Z.shiftl 0 8) with 0 in *; rewrite Z.lor_0_r.

--- a/bedrock2/src/bedrock2Examples/indirect_add.v
+++ b/bedrock2/src/bedrock2Examples/indirect_add.v
@@ -200,9 +200,9 @@ H9 : (scalar a0 (word.add va vb)
 
     (* casting scalar to bytes for stack deallocation *)
     cbv [scalar truncated_word truncated_scalar littleendian ptsto_bytes.ptsto_bytes] in *.
-    set (HList.tuple.to_list
-               (LittleEndian.split (bytes_per access_size.word)
-               (word.unsigned (word.add va vb)))) as stackbytes in *.
+    rewrite !HList.tuple.to_list_of_list.
+    repeat match goal with H : _ |- _ => rewrite !HList.tuple.to_list_of_list in H end.
+    set ((LittleEndianList.le_split (bytes_per access_size.word) (word.unsigned (word.add va vb)))) as stackbytes in *.
     assert (Datatypes.length stackbytes = 4%nat) by exact eq_refl.
     repeat straightline; eauto.
   Qed.

--- a/bedrock2/src/bedrock2Examples/insertionsort.v
+++ b/bedrock2/src/bedrock2Examples/insertionsort.v
@@ -210,8 +210,9 @@ Section WithParameters.
     unfold scalar32 at 1 3 in H.
     unfold truncated_word, truncated_scalar, littleendian, ptsto_bytes.ptsto_bytes in H.
     cbn in H.
-    eapply (ptsto_nonaliasing addr (PrimitivePair.pair._1 (LittleEndian.split 4 (word.unsigned h2)))
-                              (PrimitivePair.pair._1 (LittleEndian.split 4 (word.unsigned h1))) m).
+    rewrite !HList.tuple.to_list_of_list in H.
+    eapply (ptsto_nonaliasing addr (List.hd Byte.x00 (LittleEndianList.le_split 4 (word.unsigned h2))) (List.hd Byte.x00 (LittleEndianList.le_split 4 (word.unsigned h1))) m).
+    unfold LittleEndianList.le_split, List.hd, array in *.
     ecancel_assumption.
   Qed.
 

--- a/bedrock2/src/bedrock2Examples/lightbulb.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb.v
@@ -539,12 +539,13 @@ Section WithParameters.
           { rewrite List.app_assoc; eauto. }
           eexists; split.
           { eapply List.Forall2_app; eauto.  }
+          rewrite HList.tuple.to_list_of_list.
           destruct H29; [left|right]; repeat (straightline || split || eauto using TracePredicate.any_app_more).
           eapply TracePredicate.concat_app; eauto.
-          unshelve erewrite (_ : LittleEndian.combine _ _ = word.unsigned x10); rewrite ?word.of_Z_unsigned; try solve [intuition idtac].
-          { cbn[HList.tuple.of_list].
+          unshelve erewrite (_ : LittleEndianList.le_combine _ = word.unsigned x10); rewrite ?word.of_Z_unsigned; try solve [intuition idtac].
+          { 
             etransitivity.
-            1: eapply (LittleEndian.combine_split 4).
+            1: eapply (LittleEndianList.le_combine_split 4).
             eapply Properties.word.wrap_unsigned. } } }
 
       { split; eauto. eexists; split; eauto. split; eauto. exists nil; split; eauto.

--- a/bedrock2/src/bedrock2Examples/lightbulb_spec.v
+++ b/bedrock2/src/bedrock2Examples/lightbulb_spec.v
@@ -2,7 +2,7 @@ Require Import bedrock2.TracePredicate.
 Require Import Coq.ZArith.BinInt coqutil.Z.HexNotation.
 Require Import coqutil.Word.Interface.
 Require Import coqutil.Byte.
-Require coqutil.Word.LittleEndian.
+Require coqutil.Word.LittleEndianList.
 
 Section LightbulbSpec.
   Import BinInt TracePredicateNotations.
@@ -96,7 +96,7 @@ Section LightbulbSpec.
     spi_end) t /\
     byte.unsigned a1 = word.unsigned (word.sru a (word.of_Z 8)) /\
     byte.unsigned a0 = word.unsigned (word.and a (word.of_Z 255)) /\
-    word.unsigned v = LittleEndian.combine 4 (HList.tuple.of_list (cons b0 (cons b1 (cons b2 (cons b3 nil))))).
+    word.unsigned v = LittleEndianList.le_combine (cons b0 (cons b1 (cons b2 (cons b3 nil)))).
 
   Definition LAN9250_WRITE : byte := Byte.x02.
   Definition HW_CFG : Z := 0x074.
@@ -114,7 +114,7 @@ Section LightbulbSpec.
     spi_end) t /\
     byte.unsigned a1 = word.unsigned (word.sru a (word.of_Z 8)) /\
     byte.unsigned a0 = word.unsigned (word.and a (word.of_Z 255)) /\
-    word.unsigned v = LittleEndian.combine 4 (HList.tuple.of_list (cons b0 (cons b1 (cons b2 (cons b3 nil))))).
+    word.unsigned v = LittleEndianList.le_combine (cons b0 (cons b1 (cons b2 (cons b3 nil)))).
 
   (* NOTE: we could do this without rounding up to the nearest word, and this
   * might be necessary for other stacks than IP-TCP and IP-UDP *)
@@ -128,7 +128,7 @@ Section LightbulbSpec.
     match bs with
     | nil => eq nil
     | cons v0 (cons v1 (cons v2 (cons v3 bs))) =>
-      lan9250_fastread4 (word.of_Z 0) (word.of_Z (LittleEndian.combine 4 (HList.tuple.of_list (cons v0 (cons v1 (cons v2 (cons v3 nil))))))) +++
+      lan9250_fastread4 (word.of_Z 0) (word.of_Z (LittleEndianList.le_combine (cons v0 (cons v1 (cons v2 (cons v3 nil)))))) +++
       lan9250_readpacket bs
     | _ => constraint False (* TODO: padding? *)
     end.

--- a/bedrock2/src/bedrock2Examples/stackalloc.v
+++ b/bedrock2/src/bedrock2Examples/stackalloc.v
@@ -66,7 +66,7 @@ Section WithParameters.
     set (R := eq m).
     pose proof (eq_refl : R m) as Hm.
     repeat straightline.
-    assert (sep R (scalar32 a (Interface.word.of_Z (LittleEndian.combine _ (HList.tuple.of_list stack)))) m)
+    assert (sep R (scalar32 a (Interface.word.of_Z (LittleEndianList.le_combine stack))) m)
       by admit.
     repeat straightline.
   Abort.

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -1581,6 +1581,7 @@ Section Proofs.
       | H: _ = Some m' |- _ => move H at bottom; rename H into A
       end.
       unfold Platform.Memory.store_bytes, Memory.store_Z, Memory.store_bytes in A. fwd.
+      destruct (eq_sym (LittleEndianList.length_le_split (Memory.bytes_per(width:=width) sz) (word.unsigned val))) in t0, E.
       subst_load_bytes_for_eq.
       run1det. run1done.
       eapply preserve_subset_of_xAddrs. 1: assumption.
@@ -1693,7 +1694,7 @@ Section Proofs.
           end.
           rewrite @length_flat_map with (n := Z.to_nat bytes_per_word).
           - simpl_addrs. rewrite !Z2Nat.id by blia. rewrite <- BPW. rewrite <- Z_div_exact_2; blia.
-          - clear. intros. rewrite HList.tuple.length_to_list. reflexivity.
+          - clear. intros. eapply LittleEndianList.length_le_split.
         }
         { unfold map.split; split. 1: reflexivity. assumption. }
         { eassumption. }

--- a/compiler/src/compiler/FlatToRiscvMetric.v
+++ b/compiler/src/compiler/FlatToRiscvMetric.v
@@ -158,6 +158,7 @@ Section Proofs.
       end.
       destruct P as (finalML & P1 & P2).
       simp.
+      destruct (eq_sym (LittleEndianList.length_le_split (Memory.bytes_per(width:=width) sz) (word.unsigned val))) in t0, E.
       subst_load_bytes_for_eq.
       run1det. run1done.
       eapply preserve_subset_of_xAddrs. 1: assumption.

--- a/compiler/src/compiler/GoFlatToRiscv.v
+++ b/compiler/src/compiler/GoFlatToRiscv.v
@@ -450,12 +450,13 @@ Section Go.
     - eapply ptsto_instr_subset_to_isXAddr4.
       eapply shrink_footpr_subset. 1: eassumption. simpl. ecancel.
     - unfold Memory.loadWord.
-      eapply load_bytes_of_sep.
       unfold truncated_scalar, littleendian, Memory.bytes_per in A.
+      eapply load_bytes_of_sep with (n:=(length (LittleEndianList.le_split 4 (encode inst)))).
       (* TODO here it would be useful if seplog unfolded Memory.bytes_per for me,
          ie. did more than just syntactic unify *)
       ecancel_assumption.
-    - rewrite LittleEndian.combine_split.
+    - change 4%nat with (length (LittleEndianList.le_split 4 (encode inst))).
+      rewrite LittleEndian.combine_eq, HList.tuple.to_list_of_list, LittleEndianList.le_combine_split.
       assert (0 <= encode inst < 2 ^ width) as F. {
         pose proof (encode_range inst) as P.
         destruct width_cases as [E | E]; rewrite E; split. all: blia.

--- a/compiler/src/compiler/LowerPipeline.v
+++ b/compiler/src/compiler/LowerPipeline.v
@@ -844,6 +844,12 @@ Section LowerPipeline.
             rewrite word.of_Z_unsigned.
             solve_word_eq word_ok.
           }
+
+          Import Morphisms.
+          assert (Proper_flat_map : forall A B, Proper (pointwise_relation _ eq ==> eq ==> eq) (@flat_map A B)).
+          { clear; intros ? ? ? ? ? ? ? ?; subst; cbv [pointwise_relation] in *.
+            induction y0; cbn; congruence. }
+          setoid_rewrite LittleEndian.to_list_split.
           apply iff1ToEq, cast_word_array_to_bytes.
         }
         cbn [seps].

--- a/compiler/src/compiler/MMIO.v
+++ b/compiler/src/compiler/MMIO.v
@@ -330,7 +330,7 @@ Section MMIO1.
       change (@Bind _ _) with (@free.bind MetricMinimalMMIO.action result) in *.
       unfold free.bind at 1.
 
-      rewrite LittleEndian.combine_split.
+      rewrite <-LittleEndian.split_eq, LittleEndian.combine_split.
       rewrite Z.mod_small by eapply EncodeBound.encode_range.
       rewrite DecodeEncode.decode_encode; cycle 1. {
         unfold valid_instructions in *. cbn in *. eauto.
@@ -465,7 +465,7 @@ Section MMIO1.
       change (@Bind _ _) with (@free.bind MetricMinimalMMIO.action result) in *.
       unfold free.bind at 1.
 
-      rewrite LittleEndian.combine_split.
+      rewrite <-LittleEndian.split_eq, LittleEndian.combine_split.
       rewrite Z.mod_small by (eapply EncodeBound.encode_range).
       rewrite DecodeEncode.decode_encode; cycle 1. {
         unfold valid_instructions in *. cbn in *. eauto.

--- a/compiler/src/compiler/Spilling.v
+++ b/compiler/src/compiler/Spilling.v
@@ -1326,7 +1326,7 @@ Section Spilling.
         Memory.anybytes a ?LEN2 mStack' => replace LEN2 with LEN1; [exact H|]
       end.
       erewrite List.flat_map_const_length. 2: {
-        intros w. rewrite HList.tuple.length_to_list. reflexivity.
+        intros w. rewrite LittleEndianList.length_le_split; trivial.
       }
       blia. }
     { eassumption. }
@@ -1585,7 +1585,7 @@ Section Spilling.
           Memory.anybytes a ?LEN2 mStack' => replace LEN2 with LEN1; [exact H|]
         end.
         erewrite List.flat_map_const_length. 2: {
-          intros w. rewrite HList.tuple.length_to_list. reflexivity.
+          intros w. rewrite LittleEndianList.length_le_split; trivial.
         }
         simpl. blia. }
       { eassumption. }

--- a/compiler/src/compiler/UniqueSepLog.v
+++ b/compiler/src/compiler/UniqueSepLog.v
@@ -112,6 +112,7 @@ Require Import coqutil.Word.Interface coqutil.Word.Properties.
 Require Import coqutil.Datatypes.HList.
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.Simp.
+Require Import coqutil.Word.LittleEndian.
 Require Import bedrock2.Memory.
 Require Import bedrock2.Syntax.
 Require Import riscv.Spec.Decode.


### PR DESCRIPTION
I replaced LittleEndian with LittleEndianList in `bedrock2/`, most notably in `Scalars.v`. I did not change any high-profile definitions from tuples to lists yet. Because of this, a few new tuple-list conversions appear, and the length parameters of some tuples change from `n` to `length (le_split n v)` in a way that is inconvenient in some places. I think these would go away when `ptsto_bytes` starts taking a list instead of a tuple, but I do not dare to change that much at once. Being able to cancel out `tuple.of_list` and `tuple.to_list` instead of doing dependent-type hackery is quite satisfying, though.

I did the porting up to `FlatToRiscvCommon` where a lemma's arguments are have types dependent on an `access_size`. I don't think that place is actually stuck, but I did start wondering whether a less local solution might be nicer, and now I'm getting distracted. The fallback would be something like https://github.com/mit-plv/bedrock2/compare/LittleEndianList-transition?expand=1#diff-ecabcc922edaeb5d11aca7cb817e8a72dc43591edfe439ddd7b0d16d90b568ffR61

@samuelgruetter would you be willing to give a try to pushing this change through the compiler? I'll probably continue up towards rupicola and fiat-crypto next time I work on code, which might be notably into next week.

Here is the list of remaining occurrances of `LittleEndian`. it is not an exhaustive list of what might break, but I think I got a good sense from the half of this list that I did deal with. Also note that I am not rushing to remove `LittleEndian` from everywhere, and what we need to do to get this branch to build is largely just accounting for ripples for `Scalars.v`.

```coq
compiler/src/compiler/FlatToRiscvCommon.v:      rewrite LittleEndian.combine_split.
compiler/src/compiler/FlatToRiscvCommon.v:    rewrite bitSlice_all_nonneg. 2: cbv; discriminate. 2: apply (@LittleEndian.combine_bound 4).
compiler/src/compiler/FlatToRiscvCommon.v:    rewrite LittleEndian.split_combine.
compiler/src/compiler/FlatToRiscvCommon.v:    apply (@LittleEndian.combine_bound 4).
compiler/src/compiler/Softmul.v:    rewrite LittleEndian.combine_split. rewrite word.unsigned_of_Z_nowrap. 2: apply encode_range.
compiler/src/compiler/RunInstruction.v:                  (word.of_Z (opt_sign_extender (LittleEndian.combine n v))) /\
compiler/src/compiler/RunInstruction.v:        (Exec * ptsto_bytes n addr (LittleEndian.split n (word.unsigned v_new)) * R)%sep
compiler/src/compiler/CompilerInvariant.v:      HList.tuple.to_list (LittleEndian.split 4 (encode instr)) ++ instrencode instrs.
compiler/src/compiler/GoFlatToRiscv.v:      rewrite LittleEndian.combine_eq, HList.tuple.to_list_of_list, LittleEndianList.le_combine_split.
compiler/src/compiler/MMIO.v:  Arguments LittleEndian.combine: simpl never. (* TODO can we put this next to its definition? *)
compiler/src/compiler/MMIO.v:  Arguments LittleEndian.split: simpl never.
compiler/src/compiler/MMIO.v:      rewrite LittleEndian.combine_split.
compiler/src/compiler/MMIO.v:      rewrite LittleEndian.combine_split.
compiler/src/compiler/MMIO.v:      rewrite LittleEndian.combine_split.
compiler/src/compiler/MMIO.v:               exists (LittleEndian.split 4 0); trivial |].
compiler/src/compiler/UniqueSepLog.v:Require Import coqutil.Word.LittleEndian.
compiler/src/compiler/UniqueSepLog.v:    bytes addr (LittleEndian.split (@Memory.bytes_per width sz) (word.unsigned value)).
compiler/src/compiler/LowerPipeline.v:        exists (List.flat_map (fun x => HList.tuple.to_list (LittleEndian.split (Z.to_nat bytes_per_word) (word.unsigned x))) stack_trash).
compiler/src/compiler/Pipeline.v:      List.flat_map (fun inst => HList.tuple.to_list (LittleEndian.split 4 (encode inst))) p.
compiler/src/compiler/FlatToRiscvDef.v:    InvalidInstruction (LittleEndian.combine 4 (HList.tuple.of_list [
compiler/src/compilerExamples/AssemblyVerif.v:    gallina_prog_1 (word.of_Z (BitOps.signExtend 32 (LittleEndian.combine 4 v1)))
compiler/src/compilerExamples/AssemblyVerif.v:                   (word.of_Z (BitOps.signExtend 32 (LittleEndian.combine 4 v2))).
compiler/src/compilerExamples/AssemblyVerif.v:  Arguments LittleEndian.combine: simpl never.
compiler/src/compilerExamples/FibCompiled.v:    rewrite LittleEndian.combine_split.
compiler/src/compilerExamples/FibCompiled.v:                  | LittleEndian.split _ _ => specialize HStore with (bs := x)
compiler/src/compilerExamples/FibCompiled.v:                  | LittleEndian.split _ _ => specialize HStore with (bs := x)
compiler/src/compilerExamples/Fibonacci.v:  List.flat_map (fun inst => HList.tuple.to_list (LittleEndian.split 4 (encode inst))) insts.
```