### PR TITLE
Support fine-grained external dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,17 +22,39 @@ export COQC
 endif
 
 EXTERNAL_DEPENDENCIES?=
+EXTERNAL_COQUTIL?=
+EXTERNAL_COQ_RECORD_UPDATE?=
+EXTERNAL_RISCV_COQ?=
+EXTERNAL_KAMI?=
 
 ifneq ($(EXTERNAL_DEPENDENCIES),1)
 
+ifneq ($(EXTERNAL_COQUTIL),1)
 bedrock2_noex: coqutil
-riscv-coq: coqutil coq-record-update
-kami: riscv-coq
-compiler_noex: riscv-coq bedrock2_noex
-processor: riscv-coq kami
-end2end: compiler_ex bedrock2_ex processor
+riscv-coq: coqutil
+install: install_coqutil
+endif
 
-install: install_coqutil install_coq-record-update install_riscv-coq install_kami
+ifneq ($(EXTERNAL_COQ_RECORD_UPDATE),1)
+riscv-coq: coq-record-update
+install: install_coq-record-update
+endif
+
+ifneq ($(EXTERNAL_RISCV_COQ),1)
+kami: riscv-coq
+compiler_noex: riscv-coq
+processor: riscv-coq
+install: install_riscv-coq
+endif
+
+ifneq ($(EXTERNAL_KAMI),1)
+processor: kami
+install: install_kami
+endif
+
+compiler_noex: bedrock2_noex
+compiler_ex: bedrock2_ex
+end2end: compiler_ex bedrock2_ex processor
 
 endif
 
@@ -91,7 +113,7 @@ install_bedrock2:
 compiler_noex:
 	$(MAKE) -C $(ABS_ROOT_DIR)/compiler noex
 
-compiler_ex: compiler_noex bedrock2_ex
+compiler_ex: compiler_noex
 	$(MAKE) -C $(ABS_ROOT_DIR)/compiler
 
 clean_compiler:

--- a/bedrock2/Makefile
+++ b/bedrock2/Makefile
@@ -14,10 +14,16 @@ CC ?= cc
 DEPS_DIR ?= ../deps
 
 # Note: make does not interpret "\n", and this is intended
-DEPFLAGS_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
+DEPFLAGS_COQUTIL_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
+DEPFLAGS_NL=
 CURFLAGS_NL=-Q src/bedrock2 bedrock2\n-Q src/bedrock2Examples bedrock2Examples\n
 
 EXTERNAL_DEPENDENCIES?=
+EXTERNAL_COQUTIL?=
+
+ifneq ($(EXTERNAL_COQUTIL),1)
+DEPFLAGS_NL+=$(DEPFLAGS_COQUTIL_NL)
+endif
 
 # If we get our dependencies externally, then we should not bind the local versions of things
 ifneq ($(EXTERNAL_DEPENDENCIES),1)
@@ -65,14 +71,14 @@ special/BytedumpTest.out: special/BytedumpTest.golden.bin noex
 	mv special/BytedumpTest.out.tmp special/BytedumpTest.out
 
 special/stackloop.c: noex
-	$(BYTEDUMP) bedrock2.ToCStringStackallocLoopTest.main_cbytes > special/stackloop.c 
+	$(BYTEDUMP) bedrock2.ToCStringStackallocLoopTest.main_cbytes > special/stackloop.c
 special/stackloop: special/stackloop.c
 	$(CC) -O0 special/stackloop.c -o special/stackloop
 testStackLoop: special/stackloop
 	special/stackloop
 
 special/TypecheckExprToCString.c: noex
-	$(BYTEDUMP) bedrock2.ToCStringExprTypecheckingTest.test > special/TypecheckExprToCString.c 
+	$(BYTEDUMP) bedrock2.ToCStringExprTypecheckingTest.test > special/TypecheckExprToCString.c
 typecheckExprToCString: special/TypecheckExprToCString.c
 	$(CC) -fsyntax-only special/TypecheckExprToCString.c
 typecheckExprToCString-64: special/TypecheckExprToCString.c

--- a/compiler/Makefile
+++ b/compiler/Makefile
@@ -5,10 +5,22 @@ default_target: all
 DEPS_DIR ?= ../deps
 
 # Note: make does not interpret "\n", and this is intended
-DEPFLAGS_NL=-Q ../bedrock2/src/bedrock2 bedrock2\n-Q ../bedrock2/src/bedrock2Examples bedrock2Examples\n-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n
+DEPFLAGS_COQUTIL_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
+DEPFLAGS_RISCV_COQ_NL=-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n
+DEPFLAGS_NL=-Q ../bedrock2/src/bedrock2 bedrock2\n-Q ../bedrock2/src/bedrock2Examples bedrock2Examples\n
 CURFLAGS_NL=-Q ./src/compiler compiler\n-Q ./src/compilerExamples compilerExamples\n
 
 EXTERNAL_DEPENDENCIES?=
+EXTERNAL_COQUTIL?=
+EXTERNAL_RISCV_COQ?=
+
+ifneq ($(EXTERNAL_COQUTIL),1)
+DEPFLAGS_NL+=$(DEPFLAGS_COQUTIL_NL)
+endif
+
+ifneq ($(EXTERNAL_RISCV_COQ),1)
+DEPFLAGS_NL+=$(DEPFLAGS_RISCV_COQ_NL)
+endif
 
 # If we get our dependencies externally, then we should not bind the local versions of things
 ifneq ($(EXTERNAL_DEPENDENCIES),1)

--- a/end2end/Makefile
+++ b/end2end/Makefile
@@ -5,10 +5,28 @@ default_target: all
 DEPS_DIR ?= ../deps
 
 # Note: make does not interpret "\n", and this is intended
-DEPFLAGS_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n-Q $(DEPS_DIR)/kami/Kami/ Kami\n-Q ../processor/src/processor processor\n-Q ../bedrock2/src/bedrock2 bedrock2\n-Q ../bedrock2/src/bedrock2Examples bedrock2Examples\n-Q ../compiler/src/compiler compiler\n-Q ../compiler/src/compilerExamples compilerExamples\n
+DEPFLAGS_COQUTIL_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
+DEPFLAGS_RISCV_COQ_NL=-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n
+DEPFLAGS_KAMI_NL=-Q $(DEPS_DIR)/kami/Kami/ Kami\n
+DEPFLAGS_NL=-Q ../processor/src/processor processor\n-Q ../bedrock2/src/bedrock2 bedrock2\n-Q ../bedrock2/src/bedrock2Examples bedrock2Examples\n-Q ../compiler/src/compiler compiler\n-Q ../compiler/src/compilerExamples compilerExamples\n
 CURFLAGS_NL=-Q ./src/end2end end2end\n
 
 EXTERNAL_DEPENDENCIES?=
+EXTERNAL_COQUTIL?=
+EXTERNAL_RISCV_COQ?=
+EXTERNAL_KAMI?=
+
+ifneq ($(EXTERNAL_COQUTIL),1)
+DEPFLAGS_NL+=$(DEPFLAGS_COQUTIL_NL)
+endif
+
+ifneq ($(EXTERNAL_RISCV_COQ),1)
+DEPFLAGS_NL+=$(DEPFLAGS_RISCV_COQ_NL)
+endif
+
+ifneq ($(EXTERNAL_KAMI),1)
+DEPFLAGS_NL+=$(DEPFLAGS_KAMI_NL)
+endif
 
 # If we get our dependencies externally, then we should not bind the local versions of things
 ifneq ($(EXTERNAL_DEPENDENCIES),1)

--- a/processor/Makefile
+++ b/processor/Makefile
@@ -5,10 +5,28 @@ default_target: all
 DEPS_DIR ?= ../deps
 
 # Note: make does not interpret "\n", and this is intended
-DEPFLAGS_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n-Q $(DEPS_DIR)/kami/Kami/ Kami\n
+DEPFLAGS_COQUTIL_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
+DEPFLAGS_RISCV_COQ_NL=-Q $(DEPS_DIR)/riscv-coq/src/riscv riscv\n
+DEPFLAGS_KAMI_NL=-Q $(DEPS_DIR)/kami/Kami/ Kami\n
+DEPFLAGS_NL=
 CURFLAGS_NL=-Q ./src/processor processor\n
 
 EXTERNAL_DEPENDENCIES?=
+EXTERNAL_COQUTIL?=
+EXTERNAL_RISCV_COQ?=
+EXTERNAL_KAMI?=
+
+ifneq ($(EXTERNAL_COQUTIL),1)
+DEPFLAGS_NL+=$(DEPFLAGS_COQUTIL_NL)
+endif
+
+ifneq ($(EXTERNAL_RISCV_COQ),1)
+DEPFLAGS_NL+=$(DEPFLAGS_RISCV_COQ_NL)
+endif
+
+ifneq ($(EXTERNAL_KAMI),1)
+DEPFLAGS_NL+=$(DEPFLAGS_KAMI_NL)
+endif
 
 # If we get our dependencies externally, then we should not bind the local versions of things
 ifneq ($(EXTERNAL_DEPENDENCIES),1)


### PR DESCRIPTION
This allows `EXTERNAL_COQUTIL=1` a la
https://github.com/coq/opam-coq-archive/pull/2109 to work.