### PR TITLE
Add support for metrics in the FlatToRiscvFunctions and FlattenExpr passes

### DIFF
--- a/bedrock2/src/bedrock2/Semantics.v
+++ b/bedrock2/src/bedrock2/Semantics.v
@@ -234,11 +234,11 @@ Module exec. Section WithEnv.
       params rets fbody (_ : map.get e fname = Some (params, rets, fbody))
       args mc' (_ : evaluate_call_args_log m l arges mc = Some (args, mc'))
       lf (_ : map.of_list_zip params args = Some lf)
-      mid (_ : exec fbody t m lf mc' mid)
+      mid (_ : exec fbody t m lf (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc')))) mid)
       (_ : forall t' m' st1 mc'', mid t' m' st1 mc'' ->
           exists retvs, map.getmany_of_list st1 rets = Some retvs /\
           exists l', map.putmany_of_list_zip binds retvs l = Some l' /\
-          post t' m' l' mc'')
+          post t' m' l'  (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc'')))))
     : exec (cmd.call binds fname arges) t m l mc post
   | interact binds action arges
       t m l mc post

--- a/compiler/src/compiler/FlatImp.v
+++ b/compiler/src/compiler/FlatImp.v
@@ -298,14 +298,15 @@ Module exec.
         map.get e fname = Some (params, rets, fbody) ->
         map.getmany_of_list l args = Some argvs ->
         map.putmany_of_list_zip params argvs map.empty = Some st0 ->
-        exec fbody t m st0 (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc))) outcome ->
+        exec fbody t m st0 (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc)))) outcome ->
         (forall t' m' mc' st1,
             outcome t' m' st1 mc' ->
             exists retvs l',
               map.getmany_of_list st1 rets = Some retvs /\
               map.putmany_of_list_zip binds retvs l = Some l' /\
-              post t' m' l' (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc')))) ->
+              post t' m' l' (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc'))))) ->
         exec (SCall binds fname args) t m l mc post
+        (* TODO think about a non-fixed bound on the cost of function preamble and postamble *)
     | load: forall t m l mc sz x a o v addr post,
         map.get l a = Some addr ->
         load sz m (word.add addr (word.of_Z o)) = Some v ->
@@ -432,12 +433,12 @@ Module exec.
         map.get e fname = Some (params, rets, fbody) ->
         map.getmany_of_list l args = Some argvs ->
         map.putmany_of_list_zip params argvs map.empty = Some st ->
-        exec fbody t m st (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc)))
+        exec fbody t m st (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc))))
              (fun t' m' st' mc' =>
                 exists retvs l',
                   map.getmany_of_list st' rets = Some retvs /\
                     map.putmany_of_list_zip binds retvs l = Some l' /\
-                    post t' m' l' (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc')))) ->
+                    post t' m' l' (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc'))))) ->
       exec (SCall binds fname args) t m l mc post.
     Proof.
       intros. eapply call; try eassumption.

--- a/compiler/src/compiler/FlatImp.v
+++ b/compiler/src/compiler/FlatImp.v
@@ -298,13 +298,13 @@ Module exec.
         map.get e fname = Some (params, rets, fbody) ->
         map.getmany_of_list l args = Some argvs ->
         map.putmany_of_list_zip params argvs map.empty = Some st0 ->
-        exec fbody t m st0 mc outcome ->
+        exec fbody t m st0 (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc))) outcome ->
         (forall t' m' mc' st1,
             outcome t' m' st1 mc' ->
             exists retvs l',
               map.getmany_of_list st1 rets = Some retvs /\
               map.putmany_of_list_zip binds retvs l = Some l' /\
-              post t' m' l' mc') ->
+              post t' m' l' (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc')))) ->
         exec (SCall binds fname args) t m l mc post
     | load: forall t m l mc sz x a o v addr post,
         map.get l a = Some addr ->
@@ -432,11 +432,12 @@ Module exec.
         map.get e fname = Some (params, rets, fbody) ->
         map.getmany_of_list l args = Some argvs ->
         map.putmany_of_list_zip params argvs map.empty = Some st ->
-        exec fbody t m st mc (fun t' m' st' mc' =>
-          exists retvs l',
-            map.getmany_of_list st' rets = Some retvs /\
-            map.putmany_of_list_zip binds retvs l = Some l' /\
-            post t' m' l' mc') ->
+        exec fbody t m st (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc)))
+             (fun t' m' st' mc' =>
+                exists retvs l',
+                  map.getmany_of_list st' rets = Some retvs /\
+                    map.putmany_of_list_zip binds retvs l = Some l' /\
+                    post t' m' l' (addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 mc')))) ->
       exec (SCall binds fname args) t m l mc post.
     Proof.
       intros. eapply call; try eassumption.

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -320,6 +320,8 @@ Section WithParameters.
          map.only_differ initialL.(getRegs)
                  (union (of_list (modVars_as_list Z.eqb s)) (singleton_set RegisterNames.ra))
                  finalL.(getRegs) /\
+         (finalL.(getMetrics) - initialL.(getMetrics) <=
+          lowerMetrics (finalMetricsH - initialMetricsH))%metricsL /\    
          goodMachine finalTrace finalMH finalRegsH g finalL).
 
 End WithParameters.

--- a/compiler/src/compiler/FlatToRiscvCommon.v
+++ b/compiler/src/compiler/FlatToRiscvCommon.v
@@ -535,6 +535,7 @@ Section FlatToRiscv1.
             getMem finalL = getMem initialL /\
             getPc finalL = getNextPc initialL /\
             getNextPc finalL = word.add (getPc finalL) (word.of_Z 4) /\
+            getMetrics finalL = addMetricInstructions 1 (addMetricLoads 2 (getMetrics initialL)) /\
             valid_machine finalL).
   Proof using word_ok mem_ok PR BWM.
     intros.
@@ -575,6 +576,7 @@ Section FlatToRiscv1.
            (Exec * ptsto_word addr v_new * Rdata)%sep (getMem finalL) /\
            getPc finalL = getNextPc initialL /\
            getNextPc finalL = word.add (getPc finalL) (word.of_Z 4) /\
+           getMetrics finalL = addMetricInstructions 1 (addMetricStores 1 (addMetricLoads 1 (getMetrics initialL))) /\
            valid_machine finalL).
   Proof using word_ok mem_ok PR BWM.
     intros.

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -481,34 +481,12 @@ Section Proofs.
               (of_list
                  (list_union Z.eqb (List.firstn binds_count (reg_class.all reg_class.arg)) []))
               (singleton_set RegisterNames.ra)) (getRegs finalL) /\
-
-(* (getMetrics finalL - *)
-(*   (Platform.MetricLogging.addMetricInstructions 1 *)
-(*      (Platform.MetricLogging.addMetricJumps 1 *)
-(*         (Platform.MetricLogging.addMetricLoads 1 *)
-(*            (Platform.MetricLogging.addMetricInstructions 1 *)
-(*               (Platform.MetricLogging.addMetricLoads 1 *)
-(*                  (Platform.MetricLogging.addMetricInstructions 1 *)
-(*                     (Platform.MetricLogging.addMetricLoads 2 *)
-(*                        (Platform.MetricLogging.addMetricInstructions *)
-(*                           #(Datatypes.length *)
-(*                               (list_diff Z.eqb (modVars_as_list Z.eqb body) *)
-(*                                  (List.firstn ret_count (reg_class.all reg_class.arg)))) *)
-(*                           (Platform.MetricLogging.addMetricLoads *)
-(*                              #(Datatypes.length *)
-(*                                  (list_diff Z.eqb (modVars_as_list Z.eqb body) *)
-(*                                     (List.firstn ret_count (reg_class.all reg_class.arg))) + *)
-(*                                (Datatypes.length *)
-(*                                   (list_diff Z.eqb (modVars_as_list Z.eqb body) *)
-(*                                      (List.firstn ret_count (reg_class.all reg_class.arg))))) (getMetrics mach)))))))))) *)
-(*     <= lowerMetrics (finalMetricsH - mc))%metricsL /\ *)
-
-            (getMetrics finalL - Platform.MetricLogging.addMetricInstructions 100
-                                   (Platform.MetricLogging.addMetricJumps 100
-                                      (Platform.MetricLogging.addMetricLoads 100
-                                         (Platform.MetricLogging.addMetricStores 100 (getMetrics mach)))) <= lowerMetrics (finalMetricsH - mc))%metricsL /\
-
-            goodMachine finalTrace finalMH finalRegsH g finalL).
+          (getMetrics finalL - Platform.MetricLogging.addMetricInstructions 100
+                                 (Platform.MetricLogging.addMetricJumps 100
+                                    (Platform.MetricLogging.addMetricLoads 100
+                                       (Platform.MetricLogging.addMetricStores 100 (getMetrics mach)))) <=
+             lowerMetrics (finalMetricsH - mc))%metricsL /\
+          goodMachine finalTrace finalMH finalRegsH g finalL).
   Proof.
     intros * IHexec OC BC OL Exb GetMany Ext GE FS C V Mo Mo' Gra RaM GPC A GM.
 
@@ -1068,35 +1046,34 @@ Section Proofs.
     + eassumption.
     + solve_word_eq word_ok.
     + exact OD.
-    + assert (#(Datatypes.length (modVars_as_list Z.eqb body)) <= 29).
-      { admit. }
-      
+    + assert ((Datatypes.length (modVars_as_list Z.eqb body)) <= 29)%nat by
+        auto using NoDup_valid_FlatImp_vars_bound_length, NoDup_modVars_as_list, modVars_as_list_valid_FlatImp_var. 
       assert ((Datatypes.length
-                              (list_diff Z.eqb (modVars_as_list Z.eqb body)
-                                         (List.firstn ret_count (reg_class.all reg_class.arg))))
-              <= (Datatypes.length (modVars_as_list Z.eqb body)))%nat by apply list_diff_length. 
-      
+                 (list_diff Z.eqb (modVars_as_list Z.eqb body)
+                            (List.firstn ret_count (reg_class.all reg_class.arg))))
+              <= (Datatypes.length (modVars_as_list Z.eqb body)))%nat by
+        apply list_diff_length. 
       assert (#(Datatypes.length
                   (list_diff Z.eqb (modVars_as_list Z.eqb body)
-                             (List.firstn ret_count (reg_class.all reg_class.arg)))) <= 29) by blia.
+                             (List.firstn ret_count (reg_class.all reg_class.arg)))) <= 29) by
+        blia.
       clear - H8 H2p6.
-      
-      Ltac unfold_MetricLog ::= unfold withInstructions, withLoads, withStores, withJumps, addMetricInstructions, addMetricLoads, addMetricStores, addMetricJumps, subMetricInstructions, subMetricLoads, subMetricStores, subMetricJumps, metricsOp, metricSub, metricsSub, metricLeq, metricsLeq in *.
-
 
       cbv[lowerMetrics] in *. 
-      repeat unfold_MetricLog. 
+      unfold withInstructions, withLoads, withStores, withJumps,
+        addMetricInstructions, addMetricLoads, addMetricStores, addMetricJumps,
+        subMetricInstructions, subMetricLoads, subMetricStores, subMetricJumps,
+        metricsOp, metricSub, metricsSub, metricLeq, metricsLeq
+        in *.
       repeat simpl_MetricLog.
       remember (Datatypes.length
                   (list_diff Z.eqb (modVars_as_list Z.eqb body) (List.firstn ret_count (reg_class.all reg_class.arg)))) as blah.
 
-
       destruct mach_metrics.
       destruct middle_metrics.
-      unfold Platform.MetricLogging.metricsLeq in *.
-      unfold Platform.MetricLogging.metricLeq in *.
-      unfold Platform.MetricLogging.metricsSub in *.
-      unfold Platform.MetricLogging.metricSub in *.
+      unfold Platform.MetricLogging.metricsLeq, Platform.MetricLogging.metricLeq,
+        Platform.MetricLogging.metricsSub, Platform.MetricLogging.metricSub
+        in *.
       repeat     
         match goal with
         | |- context[?f ?n (Platform.MetricLogging.mkMetricLog ?i ?s ?l ?j)] =>
@@ -1353,7 +1330,7 @@ Section Proofs.
       wcancel_assumption.
     + reflexivity.
     + assumption.
-  Admitted. 
+  Qed. 
 
   Lemma compile_stmt_correct:
     (forall resvars extcall argvars,

--- a/compiler/src/compiler/FlatToRiscvFunctions.v
+++ b/compiler/src/compiler/FlatToRiscvFunctions.v
@@ -1507,7 +1507,7 @@ Section Proofs.
                 map.only_differ (getRegs initialL)
                   (union (of_list (modVars_as_list Z.eqb body)) (singleton_set RegisterNames.ra))
                   (getRegs finalL) /\
-                (* (getMetrics finalL - initialL_metrics <= lowerMetrics (finalMetricsH - mc))%metricsL /\ *)
+                (getMetrics finalL - initialL_metrics <= lowerMetrics (finalMetricsH - mc))%metricsL /\
                 goodMachine finalTrace finalMH finalRegsH g finalL))
         in IHexec.
       2: {
@@ -1554,7 +1554,14 @@ Section Proofs.
              goodMachine finalTrace finalMH finalRegsH g finalL)).
       2: {
         subst mach. simpl_MetricRiscvMachine_get_set.
-        intros. fwd. eauto 8 with map_hints. admit. (* SCall TODO 2 *) 
+        intros. fwd. eauto 8 with map_hints.
+        exists finalTrace. exists finalMH. exists finalRegsH. exists finalMetricsH.
+        split; eauto 8 with map_hints.
+        split; eauto 8 with map_hints.
+        split; eauto 8 with map_hints.
+        split; eauto 8 with map_hints. 
+        
+        
       }
       match goal with
       | H: (binds_count <= 8)%nat |- _ => rename H into BC

--- a/compiler/src/compiler/FlattenExpr.v
+++ b/compiler/src/compiler/FlattenExpr.v
@@ -812,7 +812,7 @@ Section FlattenExpr1.
           -- eassumption.
           -- do 2 eexists. ssplit; try eassumption.
              ++ simple eapply map.only_differ_putmany; eassumption.
-             ++ solve_MetricLog.
+             ++ solve_MetricLog. 
 
     - (* interact *)
       unfold flattenInteract in *. simp.

--- a/compiler/src/compiler/FlattenExprSimulation.v
+++ b/compiler/src/compiler/FlattenExprSimulation.v
@@ -55,9 +55,16 @@ Section Sim.
         end. *)
         (* works: apply H12. *)
         Fail eassumption.
-        match goal with
+        Fail match goal with
         | H: _ |- _ => exact H
         end.
+        intros. 
+        specialize (H14 _ _ _ _ H0). destruct H14. 
+        exists x.
+        destruct H1. split; eauto. 
+        destruct H2. exists x0. destruct H2. split; eauto.
+        remember (addMetricInstructions 100 (addMetricJumps 100 (addMetricLoads 100 (addMetricStores 100 mc'')))) as mc'''.
+        eapply H3.         
       + reflexivity.
       + reflexivity.
       + intros x k A. rewrite map.get_empty in A. discriminate.

--- a/compiler/src/compiler/MMIO.v
+++ b/compiler/src/compiler/MMIO.v
@@ -367,11 +367,14 @@ Section MMIO1.
       split; eauto.
       split; eauto.
       split; [unfold map.only_differ; eauto|].
+      split. {
+        unfold id. MetricsToRiscv.solve_MetricLog.
+      }
       split; eauto.
       split; eauto.
       split; eauto.
       split; eauto.
-      split; eauto.
+      split; eauto. 
       split. {
         lazymatch goal with
         | H: map.undef_on initialL_mem ?A |- _ =>
@@ -511,6 +514,9 @@ Section MMIO1.
         unfold map.only_differ. intros. unfold union, of_list, elem_of, singleton_set. simpl.
         rewrite map.get_put_dec.
         destruct_one_match; auto.
+      }
+      split. {
+        unfold id. MetricsToRiscv.solve_MetricLog.
       }
       split. {
         eapply map.put_extends. eassumption.

--- a/compiler/src/compiler/RunInstruction.v
+++ b/compiler/src/compiler/RunInstruction.v
@@ -11,6 +11,7 @@ Require Import riscv.Platform.Memory.
 Require Import riscv.Spec.Machine.
 Require Import riscv.Platform.RiscvMachine.
 Require Import riscv.Platform.MetricRiscvMachine.
+Require Import riscv.Platform.MetricLogging.
 Require Import riscv.Spec.Primitives.
 Require Import riscv.Spec.MetricPrimitives.
 Require Import riscv.Platform.Run.
@@ -146,6 +147,7 @@ Section Run.
         finalL.(getXAddrs) = initialL.(getXAddrs) /\
         finalL.(getPc) = word.add dest (word.of_Z oimm12) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 initialL.(getMetrics))) /\
         valid_machine finalL).
 
   Definition run_Jal_spec :=
@@ -164,6 +166,7 @@ Section Run.
         finalL.(getXAddrs) = initialL.(getXAddrs) /\
         finalL.(getPc) = word.add initialL.(getPc) (word.of_Z jimm20) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 initialL.(getMetrics))) /\
         valid_machine finalL).
 
   Definition run_Jal0_spec :=
@@ -180,6 +183,7 @@ Section Run.
         finalL.(getXAddrs) = initialL.(getXAddrs) /\
         finalL.(getPc) = word.add initialL.(getPc) (word.of_Z jimm20) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricJumps 1 (addMetricLoads 1 initialL.(getMetrics))) /\
         valid_machine finalL).
 
   Definition run_ImmReg_spec(Op: Z -> Z -> Z -> Instruction)
@@ -200,6 +204,7 @@ Section Run.
         finalL.(getXAddrs) = initialL.(getXAddrs) /\
         finalL.(getPc) = initialL.(getNextPc) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricLoads 1 initialL.(getMetrics)) /\
         valid_machine finalL).
 
   Definition run_Load_spec(n: nat)(L: Z -> Z -> Z -> Instruction)
@@ -224,6 +229,7 @@ Section Run.
         finalL.(getXAddrs) = initialL.(getXAddrs) /\
         finalL.(getPc) = initialL.(getNextPc) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricLoads 2 initialL.(getMetrics)) /\
         valid_machine finalL).
 
   Definition run_Store_spec(n: nat)(S: Z -> Z -> Z -> Instruction): Prop :=
@@ -248,6 +254,7 @@ Section Run.
           finalL.(getMem) /\
         finalL.(getPc) = initialL.(getNextPc) /\
         finalL.(getNextPc) = word.add finalL.(getPc) (word.of_Z 4) /\
+        finalL.(getMetrics) = addMetricInstructions 1 (addMetricStores 1 (addMetricLoads 1 initialL.(getMetrics))) /\
         valid_machine finalL).
 
   Ltac inline_iff1 :=
@@ -266,6 +273,7 @@ Section Run.
            | |- _ /\ _ => split
            | |- _ => solve [auto]
            | |- _ => ecancel_assumption
+           | |- _ => solve_MetricLog
            end.
 
   Ltac t := repeat intro; inline_iff1; get_run1_valid_for_free; t0.


### PR DESCRIPTION
This PR adds support for metrics to the `FlatToRiscvFunctions` compiler pass. I changed the definition of `compiles_FlatToRiscv_correctly` to add a metrics bound requiring that the cost of executing the compiled RISC-V program is less than or equal to the cost of executing the `FlatImp` source program. I updated the proof of `compile_stmt_correct` and its various helper lemmas accordingly. 

Currently, I hardcode a fixed cost of 100 instructions, loads, and stores for each function call in `FlatImp`. This accounts for the cost of saving and restoring the caller-save registers in RISC-V (up to 29 registers in this implementation). I also added this fixed cost to the semantics of the bedrock2 source language.

~This is not yet ready to merge---some things are broken in other parts of the compiler.~