### PR TITLE
Faster ensure_free

### DIFF
--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -195,15 +195,12 @@ Ltac straightline_stackdealloc :=
   clear Htmp Hsplit mStack Harray1 Hanybytes
   end.
 
-Ltac rename_to_different H := once (idtac;
+Ltac rename_to_different H :=
+  idtac;
   let G := fresh H in
-  rename H into G;
-  assert_succeeds (set (H := Set))).
+  rename H into G.
 Ltac ensure_free H :=
-  match constr:(Set) with
-  | _ => assert_succeeds (set (H := Set))
-  | _ => rename_to_different H
-  end.
+  try rename_to_different H.
 
 Ltac straightline :=
   match goal with


### PR DESCRIPTION
If you really want to be extra cautious (guard against `fresh` somehow generating a name that is not a valid target for renaming, or else is the same as the name already in the context), you can do
```
Ltac ensure_free H :=
  tryif rename_to_different H
  then assert_fails move H at bottom
  else idtac.
```
But I don't think it's necessary

This is a very minor improvement that is mostly visible in the chacha20 correctness proof that's not on master.

<details><summary>Timing Diff</summary>
<p>

```
    After |   Peak Mem | File Name                                           |    Before |   Peak Mem ||    Change || Change (mem) | % Change | % Change (mem)
--------------------------------------------------------------------------------------------------------------------------------------------------------------
18m14.86s | 1602312 ko | Total Time / Peak Mem                               | 18m17.48s | 1602284 ko || -0m02.61s ||        28 ko |   -0.23% |         +0.00%
--------------------------------------------------------------------------------------------------------------------------------------------------------------
 0m45.37s | 1000432 ko | bedrock2/src/bedrock2Examples/LiveVerif/swap.vo     |  0m46.89s | 1000520 ko || -0m01.52s ||       -88 ko |   -3.24% |         -0.00%
 8m15.79s | 1602312 ko | compiler/src/compilerExamples/Softmul.vo            |  8m15.88s | 1602284 ko || -0m00.08s ||        28 ko |   -0.01% |         +0.00%
 4m21.56s | 1014472 ko | bedrock2/src/bedrock2Examples/lightbulb.vo          |  4m22.41s | 1012484 ko || -0m00.85s ||      1988 ko |   -0.32% |         +0.19%
 1m15.44s |  594544 ko | bedrock2/src/bedrock2Examples/insertionsort.vo      |  1m15.57s |  594168 ko || -0m00.12s ||       376 ko |   -0.17% |         +0.06%
 0m58.78s |  715808 ko | bedrock2/src/bedrock2Examples/LAN9250.vo            |  0m58.84s |  715460 ko || -0m00.06s ||       348 ko |   -0.10% |         +0.04%
 0m52.39s | 1077472 ko | compiler/src/compilerExamples/SoftmulCompile.vo     |  0m52.33s | 1077624 ko || +0m00.06s ||      -152 ko |   +0.11% |         -0.01%
 0m39.08s | 1111740 ko | end2end/src/end2end/End2EndLightbulb.vo             |  0m39.13s | 1111632 ko || -0m00.05s ||       108 ko |   -0.12% |         +0.00%
 0m08.67s |  491844 ko | bedrock2/src/bedrock2Examples/SPI.vo                |  0m08.81s |  492632 ko || -0m00.14s ||      -788 ko |   -1.58% |         -0.15%
 0m07.84s |  480948 ko | bedrock2/src/bedrock2Examples/uint128_32.vo         |  0m07.87s |  481248 ko || -0m00.03s ||      -300 ko |   -0.38% |         -0.06%
 0m06.84s |  517060 ko | bedrock2/src/bedrock2Examples/FE310CompilerDemo.vo  |  0m06.97s |  518108 ko || -0m00.12s ||     -1048 ko |   -1.86% |         -0.20%
 0m06.38s |  525992 ko | compiler/src/compilerExamples/SoftmulTop.vo         |  0m06.33s |  526124 ko || +0m00.04s ||      -132 ko |   +0.78% |         -0.02%
 0m06.20s |  480020 ko | bedrock2/src/bedrock2Examples/bsearch.vo            |  0m06.16s |  480572 ko || +0m00.04s ||      -552 ko |   +0.64% |         -0.11%
 0m05.44s |  450376 ko | bedrock2/src/bedrock2Examples/FlatConstMem.vo       |  0m05.26s |  450276 ko || +0m00.18s ||       100 ko |   +3.42% |         +0.02%
 0m04.28s |  439360 ko | bedrock2/src/bedrock2Examples/indirect_add.vo       |  0m04.23s |  439420 ko || +0m00.04s ||       -60 ko |   +1.18% |         -0.01%
 0m04.02s |  459912 ko | compiler/src/compilerExamples/SoftmulBedrock2.vo    |  0m04.04s |  460056 ko || -0m00.02s ||      -144 ko |   -0.49% |         -0.03%
 0m02.91s |  436100 ko | bedrock2/src/bedrock2Examples/ipow.vo               |  0m02.89s |  436552 ko || +0m00.02s ||      -452 ko |   +0.69% |         -0.10%
 0m02.85s |  459180 ko | bedrock2/src/bedrock2Examples/SPI_live.vo           |  0m02.84s |  459256 ko || +0m00.01s ||       -76 ko |   +0.35% |         -0.01%
 0m02.46s |  433976 ko | bedrock2/src/bedrock2Examples/rpmul.vo              |  0m02.48s |  434068 ko || -0m00.02s ||       -92 ko |   -0.80% |         -0.02%
 0m02.30s |  468660 ko | compiler/src/compilerExamples/swap.vo               |  0m02.31s |  468840 ko || -0m00.01s ||      -180 ko |   -0.43% |         -0.03%
 0m01.95s |  436620 ko | bedrock2/src/bedrock2Examples/ARPResponder_live.vo  |  0m01.87s |  436864 ko || +0m00.07s ||      -244 ko |   +4.27% |         -0.05%
 0m01.38s |  437480 ko | bedrock2/src/bedrock2Examples/ARPResponderProofs.vo |  0m01.33s |  437316 ko || +0m00.04s ||       164 ko |   +3.75% |         +0.03%
 0m00.90s |  432184 ko | bedrock2/src/bedrock2Examples/ArrayLoadStore.vo     |  0m00.96s |  432192 ko || -0m00.05s ||        -8 ko |   -6.24% |         -0.00%
 0m00.70s |  429944 ko | bedrock2/src/bedrock2Examples/stackalloc.vo         |  0m00.70s |  429972 ko || +0m00.00s ||       -28 ko |   +0.00% |         -0.00%
 0m00.67s |  430004 ko | bedrock2/src/bedrock2Examples/swap.vo               |  0m00.73s |  429976 ko || -0m00.05s ||        28 ko |   -8.21% |         +0.00%
 0m00.35s |  338740 ko | bedrock2/src/bedrock2Examples/memmove.vo            |  0m00.34s |  338808 ko || +0m00.00s ||       -68 ko |   +2.94% |         -0.02%
 0m00.31s |  339332 ko | bedrock2/src/bedrock2/ProgramLogic.vo               |  0m00.31s |  339380 ko || +0m00.00s ||       -48 ko |   +0.00% |         -0.01%

```
</p>
</details>