### PR TITLE
`make bedrock2_install` now installs examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default_target: all
 
-.PHONY: update_all clone_all coqutil coq-record-update riscv-coq bedrock2_noex bedrock2_ex compiler_noex compiler_ex kami processor end2end all clean_coqutil clean_coq-record-update clean_riscv-coq clean_bedrock2 clean_compiler clean_kami clean_processor clean_end2end clean_manglenames clean install_coqutil install_coq-record-update install_kami install_riscv-coq install_bedrock2 install_compiler install_processor install_end2end install
+.PHONY: update_all clone_all coqutil coq-record-update riscv-coq bedrock2_noex bedrock2_ex compiler_noex compiler_ex kami processor end2end all clean_coqutil clean_coq-record-update clean_riscv-coq clean_bedrock2 clean_compiler clean_kami clean_processor clean_end2end clean_manglenames clean install_coqutil install_coq-record-update install_kami install_riscv-coq install_bedrock2 install_bedrock2_ex install_bedrock2_noex install_compiler install_processor install_end2end install
 
 clone_all:
 	git submodule update --init --recursive
@@ -109,6 +109,12 @@ clean_bedrock2:
 
 install_bedrock2:
 	$(MAKE) -C $(ABS_ROOT_DIR)/bedrock2 install
+
+install_bedrock2_noex:
+	$(MAKE) -C $(ABS_ROOT_DIR)/bedrock2 install_noex
+
+install_bedrock2_ex:
+	$(MAKE) -C $(ABS_ROOT_DIR)/bedrock2 install_ex
 
 compiler_noex:
 	$(MAKE) -C $(ABS_ROOT_DIR)/compiler noex

--- a/bedrock2/Makefile
+++ b/bedrock2/Makefile
@@ -1,6 +1,6 @@
 default_target: all
 
-.PHONY: clean force all noex ex install test
+.PHONY: clean force all noex ex install_noex install_ex install test
 
 # absolute paths so that emacs compile mode knows where to find error
 # use cygpath -m because Coq on Windows cannot handle cygwin paths
@@ -94,5 +94,10 @@ clean:: Makefile.coq.noex Makefile.coq.ex
 	find . -type f \( -name '*~' -o -name '*.aux' -o -name '.lia.cache' -o -name '.nia.cache' \) -delete
 	rm -f Makefile.coq.noex Makefile.coq.noex.conf Makefile.coq.ex Makefile.coq.ex.conf _CoqProject special/BytedumpTest.out
 
-install::
+install_noex::
 	$(MAKE) -f Makefile.coq.noex install
+
+install_ex::
+	$(MAKE) -f Makefile.coq.ex install
+
+install:: install_noex install_ex


### PR DESCRIPTION
We also have `bedrock2_install_{ex,noex}` targets now.

Does this organization seem reasonable?

This is for https://github.com/coq/platform/issues/178#issuecomment-1266047529; once this (or similar) is merged, I can tag a new release and update the opam packages.