### PR TITLE
0-initialize stackalloc arrays in ToCString

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ Makefile.coq.*
 
 /bedrock2/special/stackloop
 /bedrock2/special/stackloop.c
+/bedrock2/special/stacknondet
+/bedrock2/special/stacknondet.c
 /bedrock2/special/TypecheckExprToCString.c
 
 /processor/integration/program.hex

--- a/bedrock2/Makefile
+++ b/bedrock2/Makefile
@@ -46,7 +46,7 @@ ex: Makefile.coq.ex $(VS_EX) noex
 	$(MAKE) -f Makefile.coq.ex
 
 all: noex ex test
-test: special/BytedumpTest.out typecheckExprToCString testStackLoop # typecheckExprToCString-32 typecheckExprToCString-64
+test: special/BytedumpTest.out typecheckExprToCString testStackLoop testStackNondet # typecheckExprToCString-32 typecheckExprToCString-64
 
 COQ_MAKEFILE := $(COQBIN)coq_makefile -f _CoqProject INSTALLDEFAULTROOT = bedrock2 $(COQMF_ARGS)
 
@@ -76,6 +76,13 @@ special/stackloop: special/stackloop.c
 	$(CC) -O0 special/stackloop.c -o special/stackloop
 testStackLoop: special/stackloop
 	special/stackloop
+
+special/stacknondet.c: ex
+	$(BYTEDUMP) bedrock2Examples.stackalloc.stacknondet_c > special/stacknondet.c
+special/stacknondet: special/stacknondet.c
+	$(CC) special/stacknondet.c -o special/stacknondet
+testStackNondet: special/stacknondet
+	special/stacknondet
 
 special/TypecheckExprToCString.c: noex
 	$(BYTEDUMP) bedrock2.ToCStringExprTypecheckingTest.test > special/TypecheckExprToCString.c

--- a/bedrock2/src/bedrock2/ToCString.v
+++ b/bedrock2/src/bedrock2/ToCString.v
@@ -116,7 +116,7 @@ Fixpoint c_cmd (indent : string) (c : cmd) : string :=
     => indent ++ "_br2_store(" ++ c_expr ea ++ ", " ++ c_expr ev ++ ", " ++ c_size s ++ ");" ++ LF
   | cmd.stackalloc x n body =>
     let tmp := "_br2_stackalloc_"++x in (* might shadow if not fresh, likely type error... *)
-    indent ++ "{ uint8_t "++tmp++"["++c_lit n++"]; "++x++" = (uintptr_t)&"++tmp++";"++LF++
+    indent ++ "{ uint8_t "++tmp++"["++c_lit n++"] = {0}; "++x++" = (uintptr_t)&"++tmp++";"++LF++
     c_cmd indent body ++
     indent ++ "}" ++ LF
   | cmd.set x ev =>


### PR DESCRIPTION
Bedrock2 semantics leave the contents of stack-allocated arrays unspecified, but still model memory as a map from words to bytes. This implies that the freshly-allocated bytes must read as some fixed value, as opposed to ISO where reading uninitialized variables is undefined behavior.

bedrock2Examples.stackalloc.stacknondet was supposed to demonstrate the friendlier semantics of bedrock2, but it wasn't finished until now. This commit adds a proof example that reading the same uninitialized addresses twice in Bedrock2 returns the same value, and adds this example as a test.

It was manually confirmed using that valgrind rejects the test before the ToCString fix but accepts the updated version.