### PR TITLE
Proof of proper scope handling in elaborate

### DIFF
--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -294,7 +294,7 @@ Section WithMap.
     end.
 
   (* Well-formedness judgement for `expr`s, stating that an `expr` has no free
-   * variables *)
+   * variables and variables are used with correct types *)
   Inductive wf : tenv -> forall {t : type}, expr t -> Prop :=
     | wf_EVar G t (x : string) :
         map.get G x = Some (t, false) -> wf G (EVar t x)

--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -187,8 +187,8 @@ Section WithMap.
             Success (existT _ _ (ELoc t x))
         | None => error:("Undefined variable" x)
         end
-    | PEConst c =>
-        elaborate_const G c
+    | PEConst pc =>
+        elaborate_const G pc
     | PESingleton p' =>
         '(existT _ t' e') <- elaborate G p';;
         Success (existT _ _ (EBinop (OCons _) e' (EConst (CNil t'))))

--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -1,6 +1,6 @@
 Require Import PyLevelLang.Language.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString.
-Require Import coqutil.Datatypes.Result coqutil.Datatypes.List.
+Require Import coqutil.Datatypes.Result.
 Import ResultMonadNotations.
 
 (* Casts an expression `e` from `expr t2` to `expr t1`, if the two types are
@@ -63,23 +63,6 @@ Section WithMap.
   Proof.
     intros G H He.
     now apply enforce_type_pred with (e := e).
-  Qed.
-
-  Lemma existT_wf {t t'} (e : expr t) (e' : expr t') : forall G,
-    (existT expr t e = existT expr t' e') -> (wf G e -> wf G e').
-  Proof.
-    intros G H He.
-    destruct He; inversion H.
-    - apply wf_EVar.
-      now rewrite <- H2.
-    - apply wf_ELoc.
-      now rewrite <- H2.
-    - apply wf_EConst.
-    - now apply wf_EUnop.
-    - now apply wf_EBinop.
-    - now apply wf_EFlatmap.
-    - now apply wf_EIf.
-    - now apply wf_ELet.
   Qed.
 
   Definition elaborate_const (pc : pconst) : result {t & expr t} :=
@@ -276,31 +259,6 @@ Section WithMap.
       apply wf_EBinop; now apply enforce_type_wf with (G := G) in H2'.
   Qed.
 
-  Fixpoint elaborate_record (xs : list (string * {t & expr t})) :
-    result {t & expr t} :=
-    match xs with
-    | nil =>
-        Success (existT _ _ (EConst CEmpty))
-    | (s, (existT _ _ e1)) :: xs =>
-        '(existT _ _ e2) <- elaborate_record xs;;
-        Success (existT _ _ (EBinop (OPair s _ _) e1 e2))
-    end.
-
-  Lemma elaborate_record_wf (xs : list (string * {t & expr t})) : forall G t' e',
-    Forall (fun '(s, existT _ t e) => wf G e) xs ->
-    elaborate_record xs = Success (existT expr t' e') -> wf G e'.
-  Proof.
-    induction xs as [| [s [t1 e1]]]; intros G t' e' Hxs H.
-    - inversion H. apply wf_EConst.
-    - inversion H.
-      destruct elaborate_record as [[t2 e2] |]; try easy.
-      injection H1 as [= H2 H1].
-      apply existT_wf with (G := G) in H1; [easy | apply wf_EBinop].
-      + now apply Forall_inv in Hxs.
-      + apply Forall_inv_tail in Hxs.
-        now apply IHxs.
-  Qed.
-
   Fixpoint elaborate_proj {t : type} (e : expr t) (s : string) :
     result {t & expr t} :=
     match t as t' return expr t' -> _ with
@@ -327,6 +285,21 @@ Section WithMap.
       + exact H.
       + now apply wf_EUnop.
   Qed.
+
+  Section ElaborateRecord.
+    Context (elaborate : tenv -> pexpr -> result {t & expr t}).
+
+    Fixpoint elaborate_record (G : tenv) (xs : list (string * pexpr)) :
+      result {t & expr t} :=
+      match xs with
+      | nil =>
+          Success (existT _ _ (EConst CEmpty))
+      | (s, p) :: xs =>
+          '(existT _ _ e1) <- elaborate G p;;
+          '(existT _ _ e2) <- elaborate_record G xs;;
+          Success (existT _ _ (EBinop (OPair s _ _) e1 e2))
+      end.
+  End ElaborateRecord.
 
   (* Type checks a `pexpr` and possibly emits a typed expression
      Checks scoping for variables/locations *)
@@ -374,13 +347,8 @@ Section WithMap.
         let G' := map.put G x (t1, false) in
         '(existT _ t2 e2) <- elaborate G' p2;;
         Success (existT _ _ (ELet x e1 e2))
-    | PERecord xs =>
-        let f '(s, p) :=
-          e <- elaborate G p;;
-          Success (s, e)
-        in
-        xs' <- List.all_success (List.map f xs);;
-        elaborate_record xs'
+    | PERecord ps =>
+        elaborate_record elaborate G ps
     | PEProj p s =>
       '(existT _ t e) <- elaborate G p;;
         elaborate_proj e s
@@ -525,21 +493,35 @@ Section WithMap.
       + now apply IHp1.
       + apply IHp2, H2.
     - (* PERecord xs *)
-      destruct List.all_success as [xs' |] eqn : H'; try easy.
-      apply elaborate_record_wf with (xs := xs'); try easy.
-      clear H. revert xs H'.
-      induction xs' as [| [s' [t' e']]]; try easy. intros xs H'.
-      apply Forall_cons.
-      all:
-        destruct xs as [| [s p]]; try easy;
-        simpl in H';
-        destruct (elaborate G p) as [x |] eqn : H1; try easy;
-        destruct List.all_success as [xs0 |] eqn : H2; try easy;
-        injection H' as [= _ H3 H4].
-      + rewrite H3 in H1.
-        now apply elaborate_wf in H1.
-      + rewrite H4 in H2.
-        now apply IHxs' in H2.
+      revert G t e H.
+      induction xs as [| [s p]]; intros G t e H.
+      + (* nil *)
+        inversion H. apply wf_EConst.
+      + (* (s, p) :: xs *)
+        unfold elaborate_record in H.
+        destruct (elaborate G p) as [[t1 e1] |] eqn : H1; try easy.
+        assert (elaborate_record elaborate G xs =
+          (fix elaborate_record
+             (G0 : tenv) (xs0 : list (string * pexpr)) {struct xs0} :
+               result {t0 : type & expr t0} :=
+             match xs0 with
+             | nil =>
+                 Success (existT (fun t0 : type => expr t0) TEmpty (EConst CEmpty))
+             | (s0, p1) :: xs1 =>
+                 ' (existT _ x e0) <- elaborate G0 p1;;
+                 ' (existT _ x0 e2) <- elaborate_record G0 xs1;;
+                 Success
+                   (existT (fun t0 : type => expr t0) (TPair s0 x x0)
+                      (EBinop (OPair s0 x x0) e0 e2))
+             end) G xs
+        ).
+        { easy. }
+        rewrite <- H0 in H. clear H0.
+        destruct (elaborate_record elaborate G xs) as [[t2 e2] |] eqn : H2; try easy.
+        inversion H.
+        apply wf_EBinop.
+        * apply elaborate_wf in H1. exact H1.
+        * apply IHxs. exact H2.
     - (* PEProj p s *)
       unfold elaborate_proj in H.
       destruct (elaborate G p) as [[t0 e0] |] eqn : H0; try easy.

--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -11,6 +11,22 @@ Definition enforce_type (t1 : type) {t2 : type} (e : expr t2) : result (expr t1)
   | _ => error:(e "has type" t2 "but expected" t1)
   end.
 
+(* `enforce_type` preserves equality
+ * (`existT` needs to be used for the statement to typecheck) *)
+Lemma enforce_type_eq :
+  forall t t', t = t' -> forall (e : expr t) (e' : expr t'),
+  enforce_type t' e = Success e' ->
+  existT expr t e = existT expr t' e'.
+Proof.
+  intros t t' H1 e e' H2.
+  unfold enforce_type in H2.
+  destruct type_eq_dec as [H3 |]; try easy.
+  unfold cast in H2.
+  injection H2 as [= <-].
+  unfold eq_rect.
+  now destruct H3.
+Qed.
+
 Section WithMap.
   (* abstract all functions in this section over the implementation of the map,
      and over its spec (map.ok) *)

--- a/PyLevelLang/src/PyLevelLang/Examples.v
+++ b/PyLevelLang/src/PyLevelLang/Examples.v
@@ -20,42 +20,42 @@ Section Examples.
   Local Open Scope string_scope.
 
   Definition ex1 : pexpr :=
-    PEBinop POCons (PEConst (PCInt 1))
-      (PEBinop POCons (PEConst (PCInt 2))
-        (PEBinop POCons (PEConst (PCInt 3))
-          (PESingleton (PEConst (PCInt 4))))).
+    PEBinop POCons (PEAtom (PAInt 1))
+      (PEBinop POCons (PEAtom (PAInt 2))
+        (PEBinop POCons (PEAtom (PAInt 3))
+          (PESingleton (PEAtom (PAInt 4))))).
   Goal elaborate map.empty ex1 =
     Success (existT _ _
-      (EBinop (OCons _) (EConst (CInt 1))
-        (EBinop (OCons _) (EConst (CInt 2))
-          (EBinop (OCons _) (EConst (CInt 3))
-            (EBinop (OCons _) (EConst (CInt 4))
-              (EConst (CNil _))))))).
+      (EBinop (OCons _) (EAtom (AInt 1))
+        (EBinop (OCons _) (EAtom (AInt 2))
+          (EBinop (OCons _) (EAtom (AInt 3))
+            (EBinop (OCons _) (EAtom (AInt 4))
+              (EAtom (ANil _))))))).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex1 =
     Success (existT _ (TList TInt) (1 ::  2 :: 3 :: 4 :: nil)).
   reflexivity. Qed.
 
   Definition ex2 : pexpr :=
-    PEBinop POCons (PEConst (PCString "a")) (
-      PEBinop POCons (PEConst (PCInt 2)) (
-        PEBinop POCons (PEConst (PCInt 3)) (
-          PESingleton (PEConst (PCInt 4))))).
+    PEBinop POCons (PEAtom (PAString "a")) (
+      PEBinop POCons (PEAtom (PAInt 2)) (
+        PEBinop POCons (PEAtom (PAInt 3)) (
+          PESingleton (PEAtom (PAInt 4))))).
   Goal elaborate map.empty ex2 = error:(
-    (EBinop (OCons TInt) (EConst (CInt 2))
-      (EBinop (OCons TInt) (EConst (CInt 3))
-        (EBinop (OCons TInt) (EConst (CInt 4))
-          (EConst (CNil TInt)))))
+    (EBinop (OCons TInt) (EAtom (AInt 2))
+      (EBinop (OCons TInt) (EAtom (AInt 3))
+        (EBinop (OCons TInt) (EAtom (AInt 4))
+          (EAtom (ANil TInt)))))
     "has type" 
     (TList TInt)
     "but expected"
     (TList TString)).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex2 = error:(
-    (EBinop (OCons TInt) (EConst (CInt 2))
-      (EBinop (OCons TInt) (EConst (CInt 3))
-        (EBinop (OCons TInt) (EConst (CInt 4))
-          (EConst (CNil TInt)))))
+    (EBinop (OCons TInt) (EAtom (AInt 2))
+      (EBinop (OCons TInt) (EAtom (AInt 3))
+        (EBinop (OCons TInt) (EAtom (AInt 4))
+          (EAtom (ANil TInt)))))
     "has type" 
     (TList TInt)
     "but expected"
@@ -63,20 +63,20 @@ Section Examples.
   reflexivity. Qed.
 
   Definition ex3 : pexpr :=
-    PEProj (PELet "x" (PEConst (PCInt 42))
+    PEProj (PELet "x" (PEAtom (PAInt 42))
       (PEBinop POPair (PEVar "x") (PEVar "x"))) "0".
   Goal elaborate map.empty ex3 =
     Success (existT _ _
-      (EUnop (OFst _ _ _) (ELet "x" (EConst (CInt 42))
+      (EUnop (OFst _ _ _) (ELet "x" (EAtom (AInt 42))
         (EBinop (OPair "0" _ _) (EVar TInt "x")
           (EBinop (OPair "1" _ _) (EVar TInt "x")
-            (EConst CEmpty)))))).
+            (EAtom AEmpty)))))).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex3 = Success (existT _ TInt 42).
   reflexivity. Qed.
 
   Definition ex4 : pexpr :=
-    PEProj (PELet "x" (PEConst (PCInt 42))
+    PEProj (PELet "x" (PEAtom (PAInt 42))
       (PEBinop POPair (PEVar "x") (PEVar "y"))) "0".
   Goal elaborate map.empty ex4 = error:("Undefined variable" "y").
   reflexivity. Qed.
@@ -84,16 +84,16 @@ Section Examples.
   reflexivity. Qed.
 
   Definition ex5 : pexpr :=
-    PEBinop POPair (PEConst (PCInt 42))
-      (PEBinop POPair (PEConst (PCBool true)) (PEConst (PCString "hello"))).
+    PEBinop POPair (PEAtom (PAInt 42))
+      (PEBinop POPair (PEAtom (PABool true)) (PEAtom (PAString "hello"))).
   Goal elaborate map.empty ex5 =
     Success (existT _ _
-      (EBinop (OPair "0" _ _) (EConst (CInt 42))
+      (EBinop (OPair "0" _ _) (EAtom (AInt 42))
         (EBinop (OPair "1" _ _)
-          (EBinop (OPair "0" _ _) (EConst (CBool true))
-            (EBinop (OPair "1" _ _) (EConst (CString "hello"))
-              (EConst CEmpty)))
-          (EConst CEmpty)))).
+          (EBinop (OPair "0" _ _) (EAtom (ABool true))
+            (EBinop (OPair "1" _ _) (EAtom (AString "hello"))
+              (EAtom AEmpty)))
+          (EAtom AEmpty)))).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex5 =
     Success (existT _
@@ -108,16 +108,16 @@ Section Examples.
 
   Definition ex6 : pexpr :=
     PERecord
-      (("bool", PEConst (PCBool false))
-      :: ("string", PEConst (PCString "abc"))
-      :: ("int", PEConst (PCInt (-2)))
+      (("bool", PEAtom (PABool false))
+      :: ("string", PEAtom (PAString "abc"))
+      :: ("int", PEAtom (PAInt (-2)))
       :: nil).
   Goal elaborate map.empty ex6 =
     Success (existT _ _
-      (EBinop (OPair "bool" _ _) (EConst (CBool false))
-        (EBinop (OPair "string" _ _) (EConst (CString "abc"))
-          (EBinop (OPair "int" _ _) (EConst (CInt (-2)))
-            (EConst CEmpty))))).
+      (EBinop (OPair "bool" _ _) (EAtom (ABool false))
+        (EBinop (OPair "string" _ _) (EAtom (AString "abc"))
+          (EBinop (OPair "int" _ _) (EAtom (AInt (-2)))
+            (EAtom AEmpty))))).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex6 =
     Success (existT _
@@ -129,33 +129,33 @@ Section Examples.
 
   Definition ex7 : pexpr :=
     PEProj (PERecord
-      (("a", PEConst (PCBool true))
-      :: ("b", PEConst (PCInt 50))
+      (("a", PEAtom (PABool true))
+      :: ("b", PEAtom (PAInt 50))
       :: nil))
     "b".
   Goal elaborate map.empty ex7 =
     Success (existT _ _
       (EUnop (OFst _ _ _)
         (EUnop (OSnd _ _ _)
-          (EBinop (OPair "a" _ _) (EConst (CBool true))
-            (EBinop (OPair "b" _ _) (EConst (CInt 50))
-              (EConst CEmpty)))))).
+          (EBinop (OPair "a" _ _) (EAtom (ABool true))
+            (EBinop (OPair "b" _ _) (EAtom (AInt 50))
+              (EAtom AEmpty)))))).
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex7 =
     Success (existT _ TInt 50).
   reflexivity. Qed.
 
   Definition ex8 : pexpr :=
-    PEBinop POEq (PEConst (PCBool true)) (PEConst (PCInt 5)).
+    PEBinop POEq (PEAtom (PABool true)) (PEAtom (PAInt 5)).
   Goal elaborate map.empty ex8 =
-    error:((EConst (CInt 5)) "has type" TInt "but expected" TBool).
+    error:((EAtom (AInt 5)) "has type" TInt "but expected" TBool).
   reflexivity. Qed.
 
   Definition ex9 : pexpr :=
-    PEBinop POEq (PEConst (PCBool true)) (PEConst (PCBool false)).
+    PEBinop POEq (PEAtom (PABool true)) (PEAtom (PABool false)).
   Goal elaborate map.empty ex9 =
     Success (existT _ _
       (EBinop (OEq TBool eq_refl)
-        (EConst (CBool true)) (EConst (CBool false)))).
+        (EAtom (ABool true)) (EAtom (ABool false)))).
   reflexivity. Qed.
 End Examples.

--- a/PyLevelLang/src/PyLevelLang/Interpret.v
+++ b/PyLevelLang/src/PyLevelLang/Interpret.v
@@ -62,13 +62,13 @@ Section WithMap.
   Definition set_local (l : locals) {t : type} (x : string) (v : interp_type t) :
     locals := map.put l x (existT _ _ v).
 
-  Definition interp_const {t : type} (c : const t) : interp_type t :=
-    match c with
-    | CInt n => n
-    | CBool b => b
-    | CString s => s
-    | CNil t => nil
-    | CEmpty => tt
+  Definition interp_atom {t : type} (a : atom t) : interp_type t :=
+    match a with
+    | AInt n => n
+    | ABool b => b
+    | AString s => s
+    | ANil t => nil
+    | AEmpty => tt
     end.
 
   Definition interp_unop {t1 t2 : type} (o : unop t1 t2) :
@@ -106,7 +106,7 @@ Section WithMap.
   Fixpoint interp_expr (l : locals) {t : type} (e : expr t) : interp_type t :=
     match e in (expr t0) return (interp_type t0) with
     | EVar _ x | ELoc _ x => get_local l x
-    | EConst c => interp_const c
+    | EAtom a => interp_atom a
     | EUnop o e1 => interp_unop o (interp_expr l e1)
     | EBinop o e1 e2 => interp_binop o (interp_expr l e1) (interp_expr l e2)
     | EFlatmap l1 x fn => flat_map (fun y => interp_expr (set_local l x y) fn) (interp_expr l l1)

--- a/PyLevelLang/src/PyLevelLang/Language.v
+++ b/PyLevelLang/src/PyLevelLang/Language.v
@@ -28,20 +28,20 @@ Scheme Equality for type. (* creates type_beq and type_eq_dec *)
 Declare Scope pylevel_scope. Local Open Scope pylevel_scope.
 Notation "t1 =? t2" := (type_beq t1 t2) (at level 70) : pylevel_scope.
 
-(* Untyped Constants *)
-Inductive pconst : Type :=
-  | PCInt (n : Z)
-  | PCBool (b : bool)
-  | PCString (s : string)
-  | PCNil (t : type).
+(* Primitive literals (untyped) *)
+Inductive patom : Type :=
+  | PAInt (n : Z)
+  | PABool (b : bool)
+  | PAString (s : string)
+  | PANil (t : type).
 
-(* Typed Constants *)
-Inductive const : type -> Type :=
-  | CInt (n : Z) : const TInt
-  | CBool (b : bool) : const TBool
-  | CString (s : string) : const TString
-  | CNil (t : type) : const (TList t)
-  | CEmpty : const TEmpty.
+(* Primitive literals (typed) *)
+Inductive atom : type -> Type :=
+  | AInt (n : Z) : atom TInt
+  | ABool (b : bool) : atom TBool
+  | AString (s : string) : atom TString
+  | ANil (t : type) : atom (TList t)
+  | AEmpty : atom TEmpty.
 
 (* Unary operators (untyped) *)
 Inductive punop : Type :=
@@ -96,7 +96,7 @@ Inductive binop : type -> type -> type -> Type :=
 (* "Pre-expression": untyped expressions from surface-level parsing. *)
 Inductive pexpr : Type :=
   | PEVar (x : string)
-  | PEConst (pc : pconst)
+  | PEAtom (pa : patom)
   | PESingleton (p : pexpr)
   | PEUnop (po : punop) (p : pexpr)
   | PEBinop (po : pbinop) (p1 p2 : pexpr)
@@ -112,7 +112,7 @@ Inductive pexpr : Type :=
 Inductive expr : type -> Type :=
   | EVar (t : type) (x : string) : expr t
   | ELoc (t : type) (x : string) : expr t
-  | EConst {t : type} (c : const t) : expr t
+  | EAtom {t : type} (a : atom t) : expr t
   | EUnop {t1 t2 : type} (o : unop t1 t2) (e : expr t1) : expr t2
   | EBinop {t1 t2 t3 : type} (o : binop t1 t2 t3) (e1 : expr t1) (e2: expr t2) : expr t3
   | EFlatmap {t : type} (e1 : expr (TList t)) (x : string) (e2 : expr (TList t))

--- a/PyLevelLang/src/PyLevelLang/Language.v
+++ b/PyLevelLang/src/PyLevelLang/Language.v
@@ -96,7 +96,7 @@ Inductive binop : type -> type -> type -> Type :=
 (* "Pre-expression": untyped expressions from surface-level parsing. *)
 Inductive pexpr : Type :=
   | PEVar (x : string)
-  | PEConst (c : pconst)
+  | PEConst (pc : pconst)
   | PESingleton (p : pexpr)
   | PEUnop (po : punop) (p : pexpr)
   | PEBinop (po : pbinop) (p1 p2 : pexpr)

--- a/PyLevelLang/src/PyLevelLang/Notations.v
+++ b/PyLevelLang/src/PyLevelLang/Notations.v
@@ -20,9 +20,9 @@ Local Open Scope pylevel_scope.
 
 Coercion PEVar : string >-> pexpr.
 
-Coercion PCInt : Z >-> pconst.
-Coercion PCBool : bool >-> pconst.
-Coercion PEConst : pconst >-> pexpr.
+Coercion PAInt : Z >-> patom.
+Coercion PABool : bool >-> patom.
+Coercion PEAtom : patom >-> pexpr.
 
 Notation "<{ e }>"       := (e : pexpr) (at level 0, e custom pylevel at level 99, only parsing) : pylevel_scope.
 Notation "<{ e }>"       := e (at level 0, e custom pylevel at level 99, only printing) : pylevel_scope.
@@ -85,7 +85,7 @@ Notation "[ x , .. , y , z ]"   := (PEBinop POCons x .. (PEBinop POCons y (PESin
    (in custom pylevel at level 0, left associativity) : pylevel_scope.
 Notation "[ x ]"                := (PESingleton x)
    (in custom pylevel at level 0) : pylevel_scope.
-Notation "'nil(' t ')'"        := (PCNil t)
+Notation "'nil(' t ')'"        := (PANil t)
    (in custom pylevel at level 10) : pylevel_scope.
 
 
@@ -120,7 +120,7 @@ Section Tests.
    Goal <{ [ 1 ] }> = PESingleton 1.
    reflexivity. Abort.
 
-   Goal <{ true }> = PEConst (PCBool true).
+   Goal <{ true }> = PEAtom (PABool true).
    reflexivity. Abort.
 
    Goal <{ 1 :: 2 :: [3, 4] }> = PEBinop POCons 1 (PEBinop POCons 2 (PEBinop POCons 3 (PESingleton 4))).


### PR DESCRIPTION
Creates `wf`, a "well-formedness" judgement for expressions which can be used to state (in `elaborate_wf`) that `elaborate` correctly handles scope (i.e., an elaborated expression never has free variables). The soundness of the types assigned by `elaborate` is already enforced via the GADT.

The proof of `elaborate_wf` is still not complete. The parts that actually have to do with scope were not too hard to write; however, dealing with `enforce_type` and records has proven difficult. As of now, the remaining `admit`s are for proving that two type variables are equal and for the `PEProj` case. @samuelgruetter / @andres-erbsen, do you have any pointers for how to tackle these?