### PR TITLE
[in progress] working on integrating UseImmediate optimization into Pipeline.v

### DIFF
--- a/compiler/src/compiler/UseImmediate.v
+++ b/compiler/src/compiler/UseImmediate.v
@@ -5,12 +5,15 @@ Require Import bedrock2.Syntax.
 Require Import coqutil.Tactics.fwd.
 Require Import String.
 Require Import compiler.UseImmediateDef.
+Require Import bedrock2.MetricLogging.
+
+Local Notation var := String.string (only parsing).
 
 Section WithArguments.
   Context {width : Z}.
   Context {BW :  Bitwidth.Bitwidth width }.
   Context {word :  word width } {word_ok : word.ok word}.
-  Context {env :  map.map string (list string * list string * stmt string) } {env_ok : map.ok env}.
+  Context {env :  map.map string (list var * list var * stmt var) } {env_ok : map.ok env}.
   Context {mem :  map.map word (Init.Byte.byte : Type) } {mem_ok: map.ok mem}.
   Context {locals :  map.map string word } {locals_ok: map.ok locals}.
   Context {ext_spec : Semantics.ExtSpec} {ext_spec_ok: Semantics.ext_spec.ok ext_spec}.
@@ -22,47 +25,70 @@ Section WithArguments.
        morphism (word.ring_morph (word := word)),
         constants [word_cst]).
 
-  Ltac destr_exec :=
-    match goal with
-    | [ |- exec _ (match ?x with | _ => _ end) _ _ _ _ _ ] => destr x
-    | [ |- exec _ (if ?x then _ else _ ) _ _ _ _ _ ] => destr x
-    end.
-
-  Ltac apply_exec :=
-   match goal with
-   | [ |- exec _ (SSeq _ _) _ _ _ _ _ ] => apply exec.seq_cps
-   | [ |- exec _ (SLit _ _) _ _ _ _ _ ] => apply exec.lit
-   end.
-
-  Ltac inversion_exec :=
-    match goal with
-    | [ H: exec _ _ _ _ _ _ _ |- _ ] => inversion H
-    end.
-
   Local Hint Constructors exec: core.
-  Lemma useImmediateCorrect :
-    forall e st t m l mc post, exec e st t m l mc post -> exec e (useImmediate is5BitImmediate is12BitImmediate st) t m l mc post.
-  Proof.
-  intros;
-  match goal with
-  | [ H: exec _ _ _ _ _ _ _  |- _ ] => induction H
-  end;
-  simpl in *; repeat destr_exec; eauto; inversion_exec;
-  match goal with
-  | [ H: ?P _ _ _ _, H0: forall t m l mc, ?P t m l mc -> _ |- _ ] => apply H0 in H; inversion H
-  end;
-  repeat apply_exec;
-  simpl in *;
-  match goal with
-  | [ H: map.get (map.put _ ?x _) ?x = _ |- _ ] => rewrite map.get_put_same in H; fwd
-  end;
-  eapply exec.op;  simpl;
-  eauto.
-  { rewrite word.add_comm. assumption. }
-  { replace (word.add y' (word.of_Z (- v)))  with  (word.sub  y' (word.of_Z v)) by ring. assumption. }
-  { rewrite word.and_comm. assumption. }
-  { rewrite word.or_comm. assumption. }
-  { rewrite word.xor_comm. assumption. }
-  Qed.
 
+  Lemma useImmediate_correct_aux:
+    forall eH eL,
+       (useimmediate_functions is5BitImmediate is12BitImmediate) eH = Success eL ->
+       forall sH t m mcH lH post,
+       exec eH sH t m lH mcH post ->
+       exec eL (useImmediate is5BitImmediate is12BitImmediate sH) t m lH mcH post.
+  Proof.
+    induction 2.
+    (* most cases stay the same *)
+    all: try solve [simpl; eauto].
+
+    (* SCall *)
+    { simpl.
+      eapply @exec.call; try eassumption.
+      assert (exists v2, (useimmediate_function is5BitImmediate is12BitImmediate) (params, rets, fbody) = Success v2 /\ map.get eL fname = Some v2).
+      { eapply map.try_map_values_fw.
+        - simpl in H; eapply H.
+        - eassumption.
+      }
+      destruct H5. destruct H5. simpl in H5. inversion H5. fwd.
+      eassumption.
+    }
+
+    (* SSeq *)
+    { simpl.
+      repeat (match goal with
+              | |- context[match ?x with _ => _ end] => destr x
+              | |- context[if ?x then _ else _ ] => destr x
+              end;
+              try solve [eapply @exec.seq; eassumption]);
+        simpl in *.
+
+      all: eapply @exec.seq_cps; eapply @exec.lit.
+
+      all: match goal with
+           | H: exec _ _ _ _ _ _ ?mid,
+               H': forall t m l mc,
+                 ?mid _ _ _ _ -> exec ?eL _ _ _ _ _ ?post
+                 |- _ => inversion H
+           end.
+
+      all: match goal with
+           | H: ?mid _ _ _ _,
+               H0: forall t m l mc,
+                 ?mid t m l mc -> exec ?eL _ _ _ _ _ ?post
+                 |- exec ?eL _ _ _ _ _ ?post
+             => apply H0 in H; inversion H
+           end.
+
+      all: simpl in *;
+        match goal with
+        | [ H: map.get (map.put _ ?x _) ?x = _ |- _ ]
+          => rewrite map.get_put_same in H; fwd
+        end.
+
+      all: eapply @exec.op; simpl in *; [ eassumption |  reflexivity | try eassumption ].
+
+      { rewrite word.add_comm. assumption. }
+      { replace (word.add y' (word.of_Z (- v)))  with  (word.sub  y' (word.of_Z v)) by ring. assumption. }
+      { rewrite word.and_comm. assumption. }
+      { rewrite word.or_comm. assumption. }
+      { rewrite word.xor_comm. assumption. }
+    }
+  Qed.
 End WithArguments.

--- a/compiler/src/compiler/UseImmediateDef.v
+++ b/compiler/src/compiler/UseImmediateDef.v
@@ -1,22 +1,18 @@
 Require Import compiler.util.Common.
-(*
-Require Import compiler.FlattenExprDef. (* Only imported for testing UseImmediate *)
-Require Import compiler.StringNameGen. (* Only imported for testing UseImmediate *) *)
 Require Import compiler.FlatImp.
 Require Import Coq.Lists.List. Import ListNotations.
 Require Import bedrock2.Syntax.
 Require Import coqutil.Tactics.fwd.
 Require Import String.
-(* Open Scope string_scope. (* Only used for examples. *) *)
 Open Scope Z_scope.
 
-
+Local Notation var := String.string (only parsing).
 
 Section WithArgs.
   Context (is5BitImmediate : Z -> bool).
   Context (is12BitImmediate: Z -> bool).
 
-
+  Context {env: map.map String.string (list var * list var * stmt var)}.
 
   Fixpoint useImmediate(s: stmt string) : stmt string :=
     match s with
@@ -26,11 +22,7 @@ Section WithArgs.
     | SSeq s1 s2 =>
         let default := SSeq (useImmediate s1) (useImmediate s2) in
         match s1, s2 with
-        (*
-        | SSkip, _ => used2
-        | _, SSkip => used1 *)
         | SLit v1 l1, SOp v2 op v2a (Var v2b) =>
-
             match op with
             | Syntax.bopname.add
             | Syntax.bopname.and
@@ -62,78 +54,16 @@ Section WithArgs.
                                     else default
             | _ => default
             end
-        (*
-        | SLit v1 l1, SSeq (SLit v1b l1b) (SOp v2 op v2a (Var v2b)) =>
-            if (eqb v1 v1b) then default
-            else match op with
-            | Syntax.bopname.add
-            | Syntax.bopname.and
-            | Syntax.bopname.or
-            | Syntax.bopname.xor => if (is12BitImmediate l1) then
-                                      if eqb v1 v2b then
-                                        SSeq (SLit v1b l1b) (SOp v2 op v2a (Const l1))
-                                      else if eqb v1 v2a then
-                                             SSeq (SLit v1b l1b) (SOp v2 op v2b (Const l1))
-                                           else default
-                                    else default
-            | _ => default
-            end *)
         | _, _ => default
         end
     | _ => s
     end.
+
+  Definition useimmediate_function: (list string * list string * stmt string) -> result (list string * list string * stmt string) :=
+    fun '(argnames, retnames, body) =>
+      let body' := useImmediate body in
+      Success (argnames, retnames, body').
+
+  Definition useimmediate_functions : env -> result env :=
+    map.try_map_values useimmediate_function.
 End WithArgs.
-
-
-(*
-Following are examples for how UseImmediateDef works. Commented out for readability of compilation output. For now not using `Goal useImmediate (flatten_function ex_i) = expected_output because don't want to constrain expected output, what's more important is that whatever the output is is "correct" by semantics which would be shown by the proof in UseImmediate.v. To try out examples locally, uncomment here and in the imports at the start of the file.
-
-Definition ex0 := (["a"], [] : list string, Syntax.cmd.set "a" (Syntax.expr.op bopname.add (Syntax.expr.literal 1) (Syntax.expr.literal 16))).
-Definition ex1 := (["b"], ["a"], Syntax.cmd.set "b" (Syntax.expr.op bopname.slu (Syntax.expr.var "a") (Syntax.expr.literal 16))).
-Definition ex2 := (["b"], ["a"], Syntax.cmd.set "b" (Syntax.expr.op bopname.add (Syntax.expr.literal 1) (Syntax.expr.var "a"))).
-Definition ex3 := (["b"], ["a"], Syntax.cmd.set "b" (Syntax.expr.op bopname.ltu (Syntax.expr.var "a") (Syntax.expr.literal 16))).
-
-
-
-
-Definition sourceExs := [ex0; ex1; ex2; ex3].
-Definition unwrappedFlattenExs := let tmp :=  List.all_success (map flatten_function sourceExs) in
-                                  match tmp with
-                                  | Success l => l
-                                  | _ => []
-                                  end.
-Compute unwrappedFlattenExs.
-
-
-Definition useImmOnFlats (t: (list string * list string * stmt string)) : (list string * list string * stmt string)
-  := match t with
-     | (targs, trets, tstmt) => (targs, trets, (useImmediate (fun x => true) (fun x => true) tstmt))
-     end.
-
-Definition immediateExs := map useImmOnFlats unwrappedFlattenExs.
-
-(* Check that is5BitImmediate is used. *)
-Definition useImmOnFlats' (t: (list string * list string * stmt string)) : (list string * list string * stmt string)
-  := match t with
-     | (targs, trets, tstmt) => (targs, trets, (useImmediate (fun x => Z.ltb x 16) (fun x => true) tstmt))
-     end.
-
-Definition immediateExs' := map useImmOnFlats' unwrappedFlattenExs.
-
-
-
-(* Check that is12BitImmediate is used. *)
-Definition useImmOnFlats'' (t: (list string * list string * stmt string)) : (list string * list string * stmt string)
-  := match t with
-     | (targs, trets, tstmt) => (targs, trets, (useImmediate (fun x => true) (fun x => Z.ltb x 16) tstmt))
-     end.
-
-Definition immediateExs'' := map useImmOnFlats'' unwrappedFlattenExs.
-
-Compute unwrappedFlattenExs.
-(* For now, ex2 shouldn't be touched by this optimization, but could be touched after an earlier pass where superfluous SSkip's are removed. *)
-Compute immediateExs. (* All constants are small enough. *)
-Compute immediateExs'. (* is5BitImmediate is true only for < 16. *)
-Compute immediateExs''. (* is12BitImmediate is true only for < 16. *)
-
-*)

--- a/compiler/src/compilerExamples/SoftmulTop.v
+++ b/compiler/src/compilerExamples/SoftmulTop.v
@@ -89,6 +89,7 @@ Lemma verify_handler_insts : Forall (fun i => verify i Decode.RV32I) handler_ins
 Proof.
   repeat (eapply Forall_cons || eapply Forall_nil).
   all : cbv; ssplit; trivial; try congruence.
+  all : left; reflexivity.
 Qed.
 
 Lemma byte_list_to_word_list_roundtrip: forall bs,

--- a/compiler/src/compilerExamples/immediateExample.v
+++ b/compiler/src/compilerExamples/immediateExample.v
@@ -1,94 +1,63 @@
-Require Import Coq.Lists.List.
-Import ListNotations.
-Require bedrock2Examples.Demos.
-Require Import coqutil.Decidable.
 Require Import compiler.ExprImp.
-Require Import compiler.NameGen.
 Require Import compiler.Pipeline.
 Require Import riscv.Spec.Decode.
 Require Import riscv.Utility.Words32Naive.
 Require Import riscv.Utility.DefaultMemImpl32.
-Require Import riscv.Utility.Monads.
-Require Import compiler.util.Common.
-Require Import coqutil.Decidable.
 Require        riscv.Utility.InstructionNotations.
-Require Import riscv.Platform.MinimalLogging.
-Require Import bedrock2.MetricLogging.
-Require Import riscv.Platform.MetricMinimal.
-Require Import riscv.Utility.Utility.
 Require Import riscv.Utility.Encode.
 Require Import coqutil.Map.SortedList.
+Require        coqutil.Map.SortedListString.
 Require Import compiler.MemoryLayout.
-Require Import compiler.StringNameGen.
-Require Import riscv.Utility.InstructionCoercions.
-Require Import riscv.Platform.MetricRiscvMachine.
-Require bedrock2.Hexdump.
-Require Import bedrock2Examples.swap.
-Require Import bedrock2Examples.stackalloc.
-Require Import compilerExamples.SpillingTests.
-
+Require        riscv.Utility.bverify.
 Open Scope Z_scope.
 Open Scope string_scope.
 Open Scope ilist_scope.
 
-Definition var: Set := Z.
-Definition Reg: Set := Z.
-
-
-Local Existing Instance DefaultRiscvState.
-
 Local Instance funpos_env: map.map string Z := SortedListString.map _.
 
-Definition compile_ext_call(posenv: funpos_env)(mypos stackoffset: Z)(s: FlatImp.stmt Z) :=
-  match s with
-  | FlatImp.SInteract _ fname _ =>
-    if string_dec fname "nop" then
-      [[Addi Register0 Register0 0]]
-    else
-      nil
-  | _ => []
-  end.
+Definition compile_ext_call(posenv: funpos_env)(mypos stackoffset: Z)(s: FlatImp.stmt Z) : list Instruction := [].
 
-Notation RiscvMachine := MetricRiscvMachine.
+(* low_bound, hi_bound are expected inclusive bounds for UseImmediate optimization *)
+Definition test_imm_op(op: bopname.bopname)(low_bound: Z)(hi_bound: Z)
+  : (string * (list string * list string * cmd )) :=
+  (("main"),
+    (["a0"], ["ret_val"],
+      (cmd.seq (cmd.set "a0" (expr.op op (expr.var "a0")
+                                (expr.literal (low_bound - 1))))
+         (cmd.seq (cmd.set "a0" (expr.op op (expr.var "a0")
+                                   (expr.literal (low_bound))))
+            (cmd.seq (cmd.set "a0" (expr.op op (expr.var "a0")
+                                      (expr.literal (hi_bound))))
+               (cmd.set "ret_val" (expr.op op (expr.var "a0")
+                                     (expr.literal (hi_bound+1))))))))).
 
-Local Existing Instance coqutil.Map.SortedListString.map.
-Local Existing Instance coqutil.Map.SortedListString.ok.
-
-Definition main_stackalloc : (string * (list string * list string * cmd)) :=
-  ("main", ([]: list String.string, []: list String.string,
-                 cmd.stackalloc "x" 4 (cmd.stackalloc "y" 4 (cmd.call [] "imm_ex" [expr.var "x"; expr.var "y"])))).
-
-
-Definition immediate_example : (string * (list string * list string * cmd )) :=
-  ("imm_ex", ([]: list String.string, ["a"; "b"],
-                 cmd.seq (cmd.set "a" (expr.op bopname.sub (expr.literal 38) (expr.literal 31))) (cmd.set "b" (expr.op bopname.and (expr.var "a") (expr.literal 16))))).
-
-Definition allFuns: list (string * (list string * list string * cmd)) := [immediate_example; main_stackalloc].
-
-(* stack grows from high addreses to low addresses, first stack word will be written to
-   (stack_pastend-8), next stack word to (stack_pastend-16) etc *)
-Definition stack_pastend: Z := 2048.
-
-Lemma f_equal2: forall {A B: Type} {f1 f2: A -> B} {a1 a2: A},
-    f1 = f2 -> a1 = a2 -> f1 a1 = f2 a2.
-Proof. intros. congruence. Qed.
-
-Lemma f_equal3: forall {A B C: Type} {f1 f2: A -> B -> C} {a1 a2: A} {b1 b2: B},
-    f1 = f2 -> a1 = a2 -> b1 = b2 -> f1 a1 b1 = f2 a2 b2.
-Proof. intros. congruence. Qed.
-
-Lemma f_equal3_dep: forall {A B C: Type} {f1 f2: A -> B -> C} {a1 a2: A} {b1 b2: B},
-    f1 = f2 -> a1 = a2 -> b1 = b2 -> f1 a1 b1 = f2 a2 b2.
-Proof. intros. congruence. Qed.
-
+Definition imm_ex1 := test_imm_op bopname.add (-2048) (2047).
+Definition imm_ex2 := test_imm_op bopname.sub (-2047) (2048).
+Definition imm_ex3 := test_imm_op bopname.ltu (-2048) (2047).
+Definition imm_ex4 := test_imm_op bopname.lts (-2048) (2047).
+Definition imm_ex5 := test_imm_op bopname.srs 0 31.
+Definition imm_ex6 := test_imm_op bopname.slu 0 31.
 
 Local Instance RV32I_bitwidth: FlatToRiscvCommon.bitwidth_iset 32 RV32I.
 Proof. reflexivity. Qed.
 
-Definition imm_asm: list Instruction.
-  let r := eval cbv in (compile compile_ext_call allFuns) in set (res := r).
+Definition multi_compile funs_lists :=
+  List.all_success
+    (List.map
+       (fun x => '(insts, _, _) <- (compile compile_ext_call x) ;; Success insts) funs_lists).
+
+(* Expressing nested list literals as [[x]] is wonky
+   because of [[]] being used for list of Instructions *)
+Definition imm_asm: list (list Instruction).
+  let r := eval cbv in (multi_compile
+                          ([imm_ex1] ::
+                             [imm_ex2] ::
+                             [imm_ex3] ::
+                             [imm_ex4] ::
+                             [imm_ex5] ::
+                             [imm_ex6] :: [])) in set (res := r).
   match goal with
-  | res := Success (?x, _, _) |- _ => exact x
+  | res := Success (?x) |- _ => exact x
   end.
 Defined.
 
@@ -97,11 +66,12 @@ Module PrintAssembly.
   Goal True. let r := eval unfold imm_asm in imm_asm in idtac (* r *). Abort.
 End PrintAssembly.
 
-Definition imm_as_bytes: list Byte.byte := instrencode imm_asm.
-
-Module PrintBytes.
-  Import bedrock2.Hexdump.
-  Local Open Scope hexdump_scope.
-  Set Printing Width 100.
-  Goal True. let x := eval cbv in imm_as_bytes in idtac (* x *). Abort.
-End PrintBytes.
+Module CheckAssembly.
+  Goal Forall (bverify.validInstructions RV32I) imm_asm.
+    repeat (constructor; [solve
+                            [apply bverify.bvalidInstructions_valid;
+                             vm_compute; reflexivity]
+                         | ]).
+    constructor.
+  Qed.
+End CheckAssembly.


### PR DESCRIPTION
FlatImp currently has an SOp variant in its statement datatype that could be used to compile to RISC-V immediate instructions in certain cases. Optimization to do this has been written in UseImmediate.v but proof of correctness not yet integrated into main pipeline. Example has been made in end2end/src/end2end/End2EndLightbulb.v in module PrintProgram' . Difference between RISC-V assembly produced without UseImmediate and with UseImmediate at https://www.diffchecker.com/KarK1dqd/.