### PR TITLE
Reduce for lists

### DIFF
--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -52,9 +52,9 @@ Section WithMap.
     | wf_EFlatmap G {t1 t2} (e1 : expr (TList t1)) (x : string)
         (e2 : expr (TList t2)) :
         wf G e1 -> wf (map.put G x (t1, false)) e2 -> wf G (EFlatmap e1 x e2)
-    | wf_EReduce G {t1 t2} (e1 : expr (TList t1)) (e2 : expr t2) (x : string) 
+    | wf_EFold G {t1 t2} (e1 : expr (TList t1)) (e2 : expr t2) (x : string) 
         (y : string) (e3 : expr t2) :
-        wf G e1 -> wf G e2 -> wf (map.put (map.put G x (t1, false)) y (t2, false)) e3 -> wf G (EReduce e1 e2 x y e3)
+        wf G e1 -> wf G e2 -> wf (map.put (map.put G x (t1, false)) y (t2, false)) e3 -> wf G (EFold e1 e2 x y e3)
     | wf_EIf G {t} (e1 : expr TBool) (e2 e3 : expr t) :
         wf G e1 -> wf G e2 -> wf G e3 -> wf G (EIf e1 e2 e3)
     | wf_ELet G {t1 t2} (x : string) (e1 : expr t1) (e2 : expr t2) :
@@ -361,7 +361,7 @@ Section WithMap.
             end e2
         | _ => fun _ => error:(e1 "has type" t1 "but expected" TList)
         end e1
-    | PEReduce p1 p2 x y p3 =>
+    | PEFold p1 p2 x y p3 =>
         '(existT _ t1 e1) <- elaborate G p1;;
         match t1 as t' return expr t' -> _ with
         | TList t1 => fun e1 => 
@@ -369,7 +369,7 @@ Section WithMap.
             let G' := map.put (map.put G x (t1, false)) y (t2, false) in
             '(existT _ t3 e3) <- elaborate G' p3;;
             e3' <- enforce_type t2 e3;;
-            Success (existT _ _ (EReduce e1 e2 x y e3'))
+            Success (existT _ _ (EFold e1 e2 x y e3'))
         | _ => fun _ => error:(e1 "has type" t1 "but expected" TList)
         end e1
     | PEIf p1 p2 p3 =>
@@ -438,14 +438,14 @@ Section WithMap.
       apply wf_EFlatmap.
       + now apply IHp1.
       + now apply IHp2.
-    - (* PEReduce p1 p2 x y p3 *)
+    - (* PEFold p1 p2 x y p3 *)
       destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
       destruct t1; try easy.
       destruct (elaborate G p2) as [[t2 e2] |] eqn : H2; try easy.
       destruct (elaborate (map.put (map.put G x (t1, false)) y (t2, false)) p3) as [[t3 e3] |] eqn : H3; try easy.
       destruct (enforce_type t2 e3) as [e3' |] eqn : H3'; try easy.
       inversion H.
-      apply wf_EReduce.
+      apply wf_EFold.
       + now apply IHp1.
       + now apply IHp2.
       + apply IHp3. rewrite H3.

--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -108,6 +108,7 @@ Section WithMap.
       injection H as [= _ H];
       destruct t; try easy;
       repeat injection H as [= <-];
+      apply Eqdep_dec.inj_pair2_eq_dec in H as [= <-]; try exact type_eq_dec;
       apply wf_EAtom.
   Qed.
 
@@ -398,11 +399,12 @@ Section WithMap.
       destruct (map.get G x) as [[t' [|]] |] eqn : Hmap.
       + (* Some (t', true) *)
         injection H as [= H' H]. rewrite H' in H.
-        injection H as H. rewrite <- H.
+        injection H as H.
+        apply Eqdep_dec.inj_pair2_eq_dec in H as [= <-]; try exact type_eq_dec.
         apply wf_ELoc. now rewrite Hmap, H'.
       + (* Some (t', false) *)
         injection H as [= H' H]. rewrite H' in H.
-        injection H as [= <-].
+        apply Eqdep_dec.inj_pair2_eq_dec in H as [= <-]; try exact type_eq_dec.
         apply wf_EVar. now rewrite Hmap, H'.
       + (* None *)
         discriminate H.

--- a/PyLevelLang/src/PyLevelLang/Examples.v
+++ b/PyLevelLang/src/PyLevelLang/Examples.v
@@ -158,4 +158,8 @@ Section Examples.
       (EBinop (OEq TBool eq_refl)
         (EAtom (ABool true)) (EAtom (ABool false)))).
   reflexivity. Qed.
+
+  Definition ex10 : expr _ :=
+    EReduce (EBinop (OCons _) (EAtom (AInt 2)) (EBinop (OCons _) (EAtom (AInt 5)) (EAtom (ANil _)))) (EAtom (AInt 3)) "x" "y" (EBinop OPlus (EVar _ "x") (EVar _ "y")).
+  Compute interp_expr map.empty ex10.
 End Examples.

--- a/PyLevelLang/src/PyLevelLang/Examples.v
+++ b/PyLevelLang/src/PyLevelLang/Examples.v
@@ -160,6 +160,6 @@ Section Examples.
   reflexivity. Qed.
 
   Definition ex10 : expr _ :=
-    EReduce (EBinop (OCons _) (EAtom (AInt 2)) (EBinop (OCons _) (EAtom (AInt 5)) (EAtom (ANil _)))) (EAtom (AInt 3)) "x" "y" (EBinop OPlus (EVar _ "x") (EVar _ "y")).
+    EFold (EBinop (OCons _) (EAtom (AInt 2)) (EBinop (OCons _) (EAtom (AInt 5)) (EAtom (ANil _)))) (EAtom (AInt 3)) "x" "y" (EBinop OPlus (EVar _ "x") (EVar _ "y")).
   Compute interp_expr map.empty ex10.
 End Examples.

--- a/PyLevelLang/src/PyLevelLang/Interpret.v
+++ b/PyLevelLang/src/PyLevelLang/Interpret.v
@@ -49,6 +49,12 @@ Proof.
   end H); easy.
 Defined.
 
+Fixpoint  fold {A B} (fn : A -> B -> A) (a : A) (l : list B) : A :=
+  match l with
+  | nil => a
+  | x :: xs => fold fn (fn a x) xs
+  end.
+
 
 Section WithMap.
   Context {locals: map.map string {t & interp_type t}} {locals_ok: map.ok locals}.
@@ -111,6 +117,11 @@ Section WithMap.
     | EBinop o e1 e2 => interp_binop o (interp_expr l e1) (interp_expr l e2)
     | EFlatmap l1 x fn => flat_map (fun y => interp_expr (set_local l x y) fn) (interp_expr l l1)
     | EIf e1 e2 e3 => if interp_expr l e1 then interp_expr l e2 else interp_expr l e3
+    | EReduce l1 a x y fn => let l1' := interp_expr l l1 in
+                             let a' := interp_expr l a in
+                             let fn' := fun acc v => interp_expr (set_local (set_local l x v) y acc) fn in
+                             fold fn' a' l1'
+
     | ELet x e1 e2 => interp_expr (set_local l x (interp_expr l e1)) e2
     end.
 

--- a/PyLevelLang/src/PyLevelLang/Interpret.v
+++ b/PyLevelLang/src/PyLevelLang/Interpret.v
@@ -49,13 +49,6 @@ Proof.
   end H); easy.
 Defined.
 
-Fixpoint  fold {A B} (fn : A -> B -> A) (a : A) (l : list B) : A :=
-  match l with
-  | nil => a
-  | x :: xs => fold fn (fn a x) xs
-  end.
-
-
 Section WithMap.
   Context {locals: map.map string {t & interp_type t}} {locals_ok: map.ok locals}.
 
@@ -119,9 +112,8 @@ Section WithMap.
     | EIf e1 e2 e3 => if interp_expr l e1 then interp_expr l e2 else interp_expr l e3
     | EReduce l1 a x y fn => let l1' := interp_expr l l1 in
                              let a' := interp_expr l a in
-                             let fn' := fun acc v => interp_expr (set_local (set_local l x v) y acc) fn in
-                             fold fn' a' l1'
-
+                             let fn' := fun v acc => interp_expr (set_local (set_local l x v) y acc) fn in
+                             fold_right fn' a' l1'
     | ELet x e1 e2 => interp_expr (set_local l x (interp_expr l e1)) e2
     end.
 

--- a/PyLevelLang/src/PyLevelLang/Interpret.v
+++ b/PyLevelLang/src/PyLevelLang/Interpret.v
@@ -110,7 +110,7 @@ Section WithMap.
     | EBinop o e1 e2 => interp_binop o (interp_expr l e1) (interp_expr l e2)
     | EFlatmap l1 x fn => flat_map (fun y => interp_expr (set_local l x y) fn) (interp_expr l l1)
     | EIf e1 e2 e3 => if interp_expr l e1 then interp_expr l e2 else interp_expr l e3
-    | EReduce l1 a x y fn => let l1' := interp_expr l l1 in
+    | EFold l1 a x y fn => let l1' := interp_expr l l1 in
                              let a' := interp_expr l a in
                              let fn' := fun v acc => interp_expr (set_local (set_local l x v) y acc) fn in
                              fold_right fn' a' l1'

--- a/PyLevelLang/src/PyLevelLang/Language.v
+++ b/PyLevelLang/src/PyLevelLang/Language.v
@@ -101,6 +101,7 @@ Inductive pexpr : Type :=
   | PEUnop (po : punop) (p : pexpr)
   | PEBinop (po : pbinop) (p1 p2 : pexpr)
   | PEFlatmap (p1 : pexpr) (x : string) (p2 : pexpr)
+  | PEReduce (p1 : pexpr) (p2 : pexpr) (x : string) (y : string) (p2 : pexpr)
   | PEIf (p1 p2 p3 : pexpr)
   | PELet (x : string) (p1 p2 : pexpr)
   | PERecord (xs : list (string * pexpr))
@@ -117,6 +118,7 @@ Inductive expr : type -> Type :=
   | EBinop {t1 t2 t3 : type} (o : binop t1 t2 t3) (e1 : expr t1) (e2: expr t2) : expr t3
   | EFlatmap {t1 t2 : type} (e1 : expr (TList t1)) (x : string) (e2 : expr (TList t2))
       : expr (TList t2)
+  | EReduce {t1 t2 : type} (e1 : expr (TList t1)) (e2 : expr t2) (x y : string) (e3 : expr t2) : expr t2
   | EIf {t : type} (e1 : expr TBool) (e2 e3 : expr t) : expr t
   | ELet {t1 t2 : type} (x : string) (e1 : expr t1) (e2 : expr t2) : expr t2.
 

--- a/PyLevelLang/src/PyLevelLang/Language.v
+++ b/PyLevelLang/src/PyLevelLang/Language.v
@@ -23,7 +23,12 @@ Definition can_eq (t : type) : bool :=
   | _ => false
   end.
 
-Scheme Equality for type. (* creates type_beq and type_eq_dec *)
+Definition type_eq_dec (t1 t2 : type) : {t1 = t2} + {t1 <> t2}.
+decide equality.
+apply string_dec.
+Defined.
+
+Scheme Boolean Equality for type. (* creates type_beq *)
 
 Declare Scope pylevel_scope. Local Open Scope pylevel_scope.
 Notation "t1 =? t2" := (type_beq t1 t2) (at level 70) : pylevel_scope.

--- a/PyLevelLang/src/PyLevelLang/Language.v
+++ b/PyLevelLang/src/PyLevelLang/Language.v
@@ -106,7 +106,7 @@ Inductive pexpr : Type :=
   | PEUnop (po : punop) (p : pexpr)
   | PEBinop (po : pbinop) (p1 p2 : pexpr)
   | PEFlatmap (p1 : pexpr) (x : string) (p2 : pexpr)
-  | PEReduce (p1 : pexpr) (p2 : pexpr) (x : string) (y : string) (p2 : pexpr)
+  | PEFold (p1 : pexpr) (p2 : pexpr) (x : string) (y : string) (p2 : pexpr)
   | PEIf (p1 p2 p3 : pexpr)
   | PELet (x : string) (p1 p2 : pexpr)
   | PERecord (xs : list (string * pexpr))
@@ -123,7 +123,7 @@ Inductive expr : type -> Type :=
   | EBinop {t1 t2 t3 : type} (o : binop t1 t2 t3) (e1 : expr t1) (e2: expr t2) : expr t3
   | EFlatmap {t1 t2 : type} (e1 : expr (TList t1)) (x : string) (e2 : expr (TList t2))
       : expr (TList t2)
-  | EReduce {t1 t2 : type} (e1 : expr (TList t1)) (e2 : expr t2) (x y : string) (e3 : expr t2) : expr t2
+  | EFold {t1 t2 : type} (e1 : expr (TList t1)) (e2 : expr t2) (x y : string) (e3 : expr t2) : expr t2
   | EIf {t : type} (e1 : expr TBool) (e2 e3 : expr t) : expr t
   | ELet {t1 t2 : type} (x : string) (e1 : expr t1) (e2 : expr t2) : expr t2.
 

--- a/PyLevelLang/src/PyLevelLang/Notations.v
+++ b/PyLevelLang/src/PyLevelLang/Notations.v
@@ -123,7 +123,7 @@ Notation "'nil[' t ']'"        := (PANil t)
 (* Other pexpr *)
 Notation "'flatmap' e1 x e2"           := (PEFlatmap e1 x%string e2)
    (in custom py_expr at level 99, x constr at level 0) : pylevel_scope.
-Notation "'reduce' e1 e2 x y e3"           := (PEReduce e1 e2 x%string y%string e3)
+Notation "'fold' e1 e2 x y e3"           := (PEFold e1 e2 x%string y%string e3)
    (in custom py_expr at level 99, x constr at level 0, y constr at level 0) : pylevel_scope.
 Notation "'if' p1 'then' p2 'else' p3" := (PEIf p1 p2 p3)
    (in custom py_expr at level 99) : pylevel_scope.

--- a/PyLevelLang/src/PyLevelLang/Notations.v
+++ b/PyLevelLang/src/PyLevelLang/Notations.v
@@ -123,6 +123,8 @@ Notation "'nil[' t ']'"        := (PANil t)
 (* Other pexpr *)
 Notation "'flatmap' e1 x e2"           := (PEFlatmap e1 x%string e2)
    (in custom py_expr at level 99, x constr at level 0) : pylevel_scope.
+Notation "'reduce' e1 e2 x y e3"           := (PEReduce e1 e2 x%string y%string e3)
+   (in custom py_expr at level 99, x constr at level 0, y constr at level 0) : pylevel_scope.
 Notation "'if' p1 'then' p2 'else' p3" := (PEIf p1 p2 p3)
    (in custom py_expr at level 99) : pylevel_scope.
 Notation "'let' x := p1 'in' p2"       := (PELet x p1 p2)
@@ -222,6 +224,5 @@ Section Tests.
                          (PCGets "b" (PEBinop POPlus "x" 1))))
                (PCGets "z" 123).
    reflexivity. Abort.
-
 End Tests.
 

--- a/PyLevelLang/src/PyLevelLang/Optimize.v
+++ b/PyLevelLang/src/PyLevelLang/Optimize.v
@@ -192,7 +192,7 @@ Section WithMap.
       | EUnop o e1 => EUnop o (fold_expr e1)
       | EBinop o e1 e2 => EBinop o (fold_expr e1) (fold_expr e2)
       | EFlatmap e1 x e2 => EFlatmap (fold_expr e1) x (fold_expr e2)
-      | EReduce e1 e2 x y e3 => EReduce (fold_expr e1) (fold_expr e2) x y (fold_expr e3)
+      | EFold e1 e2 x y e3 => EFold (fold_expr e1) (fold_expr e2) x y (fold_expr e3)
       | EIf e1 e2 e3 => EIf (fold_expr e1) (fold_expr e2) (fold_expr e3)
       | ELet x e1 e2 => ELet x (fold_expr e1) (fold_expr e2)
       | (EVar _ _ | ELoc _ _ | EAtom _) as e => e
@@ -220,7 +220,7 @@ Section WithMap.
         | _, _ => (EBinop o e1' e2', None)
         end
     | EFlatmap e1 x e2 => (EFlatmap (fst (constant_folding' e1)) x (fst (constant_folding' e2)), None)
-    | EReduce e1 e2 x y e3 => (EReduce (fst(constant_folding' e1)) (fst(constant_folding' e2)) x y (fst(constant_folding' e3)), None)
+    | EFold e1 e2 x y e3 => (EFold (fst(constant_folding' e1)) (fst(constant_folding' e2)) x y (fst(constant_folding' e3)), None)
     | EIf e1 e2 e3 => (EIf (fst (constant_folding' e1)) (fst (constant_folding' e2)) (fst (constant_folding' e3)), None)
     | ELet x e1 e2 => (ELet x (fst (constant_folding' e1)) (fst (constant_folding' e2)), None)
     end.
@@ -306,7 +306,7 @@ Section WithMap.
         | _ => EIf e1' e2' e3'
         end
     | EFlatmap e1 x e2 => EFlatmap (branch_elim e1) x (branch_elim e2)
-    | EReduce e1 e2 x y e3 => EReduce (branch_elim e1) (branch_elim e2) x y (branch_elim e3)
+    | EFold e1 e2 x y e3 => EFold (branch_elim e1) (branch_elim e2) x y (branch_elim e3)
     | ELet x e1 e2 => ELet x (branch_elim e1) (branch_elim e2)
     end.
 
@@ -339,7 +339,7 @@ Section WithMap.
     | EUnop _ e1 => is_name_used x e1
     | EBinop _ e1 e2 => is_name_used x e1 || is_name_used x e2
     | EFlatmap e1 x' e2 => eqb x' x || is_name_used x e1 || is_name_used x e2
-    | EReduce e1 e2 x' y' e3 => eqb x' x || eqb y' x || is_name_used x e1 || is_name_used x e2 || is_name_used x e3
+    | EFold e1 e2 x' y' e3 => eqb x' x || eqb y' x || is_name_used x e1 || is_name_used x e2 || is_name_used x e3
     | EIf e1 e2 e3 => is_name_used x e1 || is_name_used x e2 || is_name_used x e3
     | ELet x' e1 e2 => eqb x' x || is_name_used x e1 || is_name_used x e2
     end.
@@ -434,7 +434,7 @@ Section WithMap.
     | EUnop o e1 => EUnop o (unused_name_elim e1)
     | EBinop o e1 e2 => EBinop o (unused_name_elim e1) (unused_name_elim e2)
     | EFlatmap e1 x e2 => EFlatmap (unused_name_elim e1) x (unused_name_elim e2)
-    | EReduce e1 e2 x y e3 => EReduce (unused_name_elim e1) (unused_name_elim e2) x y (unused_name_elim e3)
+    | EFold e1 e2 x y e3 => EFold (unused_name_elim e1) (unused_name_elim e2) x y (unused_name_elim e3)
     | EIf e1 e2 e3 => EIf (unused_name_elim e1) (unused_name_elim e2) (unused_name_elim e3)
     | ELet x e1 e2 => if is_name_used x e2 then ELet x (unused_name_elim e1) (unused_name_elim e2) else unused_name_elim e2
     end.

--- a/PyLevelLang/src/PyLevelLang/Optimize.v
+++ b/PyLevelLang/src/PyLevelLang/Optimize.v
@@ -163,10 +163,11 @@ Section WithMap.
     <-> e = EBinop (OPair X A B) e1 e2.
   Proof.
     clear dependent locals.
-    dependent induction e; cbn; intuition try congruence;
-    dependent induction o; inversion H; congruence.
+    dependent induction e; cbn; intuition; try congruence;
+    dependent induction o; inversion H; 
+    try apply Eqdep.EqdepTheory.inj_pair2 in H1, H2; try exact type_eq_dec; 
+    congruence.
   Qed.
-
 
   Lemma EUnop_correct {t1 t2 : type} (l : locals) (o : unop t1 t2) (e : expr t1)
     : interp_expr l (eUnop o e) = interp_expr l (EUnop o e).

--- a/PyLevelLang/src/PyLevelLang/Optimize.v
+++ b/PyLevelLang/src/PyLevelLang/Optimize.v
@@ -191,6 +191,7 @@ Section WithMap.
       | EUnop o e1 => EUnop o (fold_expr e1)
       | EBinop o e1 e2 => EBinop o (fold_expr e1) (fold_expr e2)
       | EFlatmap e1 x e2 => EFlatmap (fold_expr e1) x (fold_expr e2)
+      | EReduce e1 e2 x y e3 => EReduce (fold_expr e1) (fold_expr e2) x y (fold_expr e3)
       | EIf e1 e2 e3 => EIf (fold_expr e1) (fold_expr e2) (fold_expr e3)
       | ELet x e1 e2 => ELet x (fold_expr e1) (fold_expr e2)
       | (EVar _ _ | ELoc _ _ | EAtom _) as e => e
@@ -218,6 +219,7 @@ Section WithMap.
         | _, _ => (EBinop o e1' e2', None)
         end
     | EFlatmap e1 x e2 => (EFlatmap (fst (constant_folding' e1)) x (fst (constant_folding' e2)), None)
+    | EReduce e1 e2 x y e3 => (EReduce (fst(constant_folding' e1)) (fst(constant_folding' e2)) x y (fst(constant_folding' e3)), None)
     | EIf e1 e2 e3 => (EIf (fst (constant_folding' e1)) (fst (constant_folding' e2)) (fst (constant_folding' e3)), None)
     | ELet x e1 e2 => (ELet x (fst (constant_folding' e1)) (fst (constant_folding' e2)), None)
     end.
@@ -275,6 +277,12 @@ Section WithMap.
       rewrite <- H.
       reflexivity.
 
+    - rewrite IHe1.
+      f_equal; eauto.
+      apply functional_extensionality. intros.
+      apply functional_extensionality. intros.
+      easy.
+
     - rewrite IHe1, IHe2, IHe3. reflexivity.
 
     - rewrite IHe1, IHe2. reflexivity.
@@ -297,6 +305,7 @@ Section WithMap.
         | _ => EIf e1' e2' e3'
         end
     | EFlatmap e1 x e2 => EFlatmap (branch_elim e1) x (branch_elim e2)
+    | EReduce e1 e2 x y e3 => EReduce (branch_elim e1) (branch_elim e2) x y (branch_elim e3)
     | ELet x e1 e2 => ELet x (branch_elim e1) (branch_elim e2)
     end.
 
@@ -313,6 +322,10 @@ Section WithMap.
       { apply functional_extensionality. intros. rewrite IHe2. reflexivity. }
       rewrite H. reflexivity.
 
+    - f_equal. 
+      do 2 (apply functional_extensionality; intros).
+      easy.
+
     - destruct (as_const (branch_elim e1)) eqn:H; try easy.
       destruct i; rewrite (as_const_correct l (branch_elim e1) _ H); reflexivity.
   Qed.
@@ -325,6 +338,7 @@ Section WithMap.
     | EUnop _ e1 => is_name_used x e1
     | EBinop _ e1 e2 => is_name_used x e1 || is_name_used x e2
     | EFlatmap e1 x' e2 => eqb x' x || is_name_used x e1 || is_name_used x e2
+    | EReduce e1 e2 x' y' e3 => eqb x' x || eqb y' x || is_name_used x e1 || is_name_used x e2 || is_name_used x e3
     | EIf e1 e2 e3 => is_name_used x e1 || is_name_used x e2 || is_name_used x e3
     | ELet x' e1 e2 => eqb x' x || is_name_used x e1 || is_name_used x e2
     end.
@@ -380,7 +394,21 @@ Section WithMap.
                 + apply IHe2. reflexivity.
                 + apply eqb_neq, Hx.
               }
-              rewrite Hf. rewrite <- IHe1; easy. 
+              rewrite Hf. rewrite <- IHe1; easy.
+
+    - destruct (eqb x0 x) eqn:H0x; 
+      destruct (eqb y x) eqn:Hyx;
+      destruct (is_name_used x e1) eqn:He1;
+      destruct (is_name_used x e2) eqn:He2;
+      destruct (is_name_used x e3) eqn:He3; 
+      try discriminate H.
+      f_equal; eauto.
+      do 2 (apply functional_extensionality; intros).
+      rewrite <- set_local_comm_diff with (x := x); cycle 1.
+      { apply eqb_neq. rewrite eqb_sym. assumption. }
+      rewrite <- set_local_comm_diff with (x := x); cycle 1.
+      { apply eqb_neq. rewrite eqb_sym. assumption. }
+      apply IHe3. reflexivity.
 
     - rewrite <- IHe1, <- IHe2, <- IHe3;
       destruct (is_name_used x e1); 
@@ -405,6 +433,7 @@ Section WithMap.
     | EUnop o e1 => EUnop o (unused_name_elim e1)
     | EBinop o e1 e2 => EBinop o (unused_name_elim e1) (unused_name_elim e2)
     | EFlatmap e1 x e2 => EFlatmap (unused_name_elim e1) x (unused_name_elim e2)
+    | EReduce e1 e2 x y e3 => EReduce (unused_name_elim e1) (unused_name_elim e2) x y (unused_name_elim e3)
     | EIf e1 e2 e3 => EIf (unused_name_elim e1) (unused_name_elim e2) (unused_name_elim e3)
     | ELet x e1 e2 => if is_name_used x e2 then ELet x (unused_name_elim e1) (unused_name_elim e2) else unused_name_elim e2
     end.
@@ -423,6 +452,10 @@ Section WithMap.
               = (fun y => interp_expr (set_local l x y) e2)).
       { apply functional_extensionality. intros. rewrite IHe2. reflexivity. }
       rewrite IHe1, H. reflexivity.
+
+    - f_equal; eauto.
+      do 2 (apply functional_extensionality; intros).
+      eauto.
 
     - rewrite IHe1, IHe2, IHe3. reflexivity.
 

--- a/PyLevelLang/src/PyLevelLang/SamplePrograms.v
+++ b/PyLevelLang/src/PyLevelLang/SamplePrograms.v
@@ -120,6 +120,16 @@ Section Examples.
      = Success [("o", existT interp_type (TList TInt) [1; 4; 9; 16; 25; 36; 49; 64; 81])].
   Proof. reflexivity. Abort.
 
+  Goal run_program [("o", (TInt, true))] <{
+    "o" <- reduce range(1, 10) 0 "x" "y" ("x" + "y") }>
+    = Success [("o", existT interp_type TInt 45)].
+  reflexivity. Abort.
+
+  Goal run_program [("o", (TInt, true))] <{
+    "o" <- reduce range(1, 10) 0 "x" "y" ("x" * "x" + "y") }>
+    = Success [("o", existT interp_type TInt 285)].
+  reflexivity. Abort.
+
    Definition isEven (n : Z) : pcommand := <{
       let "n" := n in
       if "n" % 2 == 0

--- a/PyLevelLang/src/PyLevelLang/SamplePrograms.v
+++ b/PyLevelLang/src/PyLevelLang/SamplePrograms.v
@@ -121,12 +121,12 @@ Section Examples.
   Proof. reflexivity. Abort.
 
   Goal run_program [("o", (TInt, true))] <{
-    "o" <- reduce range(1, 10) 0 "x" "y" ("x" + "y") }>
+    "o" <- fold range(1, 10) 0 "x" "y" ("x" + "y") }>
     = Success [("o", existT interp_type TInt 45)].
   reflexivity. Abort.
 
   Goal run_program [("o", (TInt, true))] <{
-    "o" <- reduce range(1, 10) 0 "x" "y" ("x" * "x" + "y") }>
+    "o" <- fold range(1, 10) 0 "x" "y" ("x" * "x" + "y") }>
     = Success [("o", existT interp_type TInt 285)].
   reflexivity. Abort.
 


### PR DESCRIPTION
I've implemented a `reduce` operation for lists. I've also added elaboration and notations for reduce.
This PR also includes the new `type_eq_dec` (no longer relying on `Scheme Equality`) and the associated changes to the elaborator we discussed during the last meeting.