### PR TITLE
Expr notations and partial progress with substitute

### DIFF
--- a/PyLevelLang/src/PyLevelLang/Optimize.v
+++ b/PyLevelLang/src/PyLevelLang/Optimize.v
@@ -706,7 +706,7 @@ Section WithMap.
 
   (* First attempt at implementing substitute. 
      HAS A BUG - see comment for ELet *)
-  Fail Fixpoint substitute {t tx : type} (x : string) (ex : expr tx) (e : expr t): expr t
+  Fixpoint substitute {t tx : type} (x : string) (ex : expr tx) (e : expr t): expr t
     := match e in expr t' return expr t' with
        | EVar t' x' => match type_eq_dec tx t', String.eqb x x' return expr t' with
                        | left H, true => cast H _ ex
@@ -728,20 +728,18 @@ Section WithMap.
        | EIf e1 e2 e3 => EIf (substitute x ex e1) (substitute x ex e2) (substitute x ex e3)
 
        (* We should rename `x'` to something that does not occur in `ex` *)
+       (* We should also substitute occurrences of `x` in `ex'` *)
        | ELet x' ex' e' => if String.eqb x x' || is_name_used x' ex
                              then ELet x' ex' e'
                              else ELet x' ex' (substitute x ex e')
-
-       | _ => _ (* Silly case to make this command fail *)
        end.
 
   (* Correct, but old and not-strong-enough version of substitute_correct.
      PHOAS was suggested as a possible approach to prove the right version.
      For the meantime, I've left the old version here... *)
-  Fail Lemma substitute_correct' {t tx : type} (l : locals) (x : string) (ex : expr tx) (e : expr t) :
+  Lemma substitute_correct' {t tx : type} (l : locals) (x : string) (ex : expr tx) (e : expr t) :
     get_local l x = interp_expr l ex -> interp_expr l (substitute x ex e) = interp_expr l e.
-  Fail Proof.
-  (*
+  Proof.
     generalize dependent l.
     induction e; intros; simpl.
     - repeat (destruct_one_match; eauto). now subst.
@@ -780,6 +778,6 @@ Section WithMap.
       rewrite map.get_put_diff; eauto.
       rewrite H.
       now rewrite is_name_used_correct.
-  *)
-   Fail Abort.
+  Abort.
+
 End WithMap.

--- a/PyLevelLang/src/PyLevelLang/Queries.v
+++ b/PyLevelLang/src/PyLevelLang/Queries.v
@@ -102,13 +102,140 @@ Section Queries_Section.
 
   Local Open Scope pylevel_scope.
 
+  (* SELECT * FROM artists WHERE id < 3 *)
   Definition filter_test := <{
     "ans" <- flatmap artists' "x" (if "x"["id"] < 3 then ["x"] else nil[artist])
     }>.
+  Compute run_program ((("ans", (TList artist, true)) :: nil)) filter_test.
+
+  (* SELECT SUM(id) FROM artists *)
+  Definition fold_test := <{
+    "ans" <- fold artists' 0 "x" "y" ("x"["id"] + "y")
+  }>.
+  Compute run_program ((("ans", (TInt, true)) :: nil)) fold_test.
+
+  (* SELECT name FROM artists WHERE id < 3 *)
+  Definition select_test := <{
+    "ans" <- flatmap (flatmap artists' "x" (if "x"["id"] < 3 then ["x"] else nil[artist])) "y" ["y"["name"]]
+  }>.
+  Compute run_program ((("ans", (TList TString, true)) :: nil)) select_test.
+
+  Definition select_test_elaborated' : command := 
+    Eval cbv in match elaborate_command (map.of_list (("ans", (TList TString, true))::nil)) select_test with
+    | Success x => x
+    | _ => _
+    end.
+  
+  Definition select_test_elaborated := Eval cbv in match select_test_elaborated' with
+                                                    | CGets _ e => e
+                                                    | _ => _
+                                                    end.
+  Compute select_test_elaborated.
+  Compute flatmap_flatmap select_test_elaborated.
+  Compute interp_expr map.empty select_test_elaborated.
+
+  Definition album := record (("album_id", TInt) :: ("title", TString) :: ("artist_id", TInt) :: nil).
+  Definition albums := pexpr_list album (map from_tuple'
+    ((1, ("For Those About To Rock We Salute You", (1, tt)))
+      :: (2, ("Balls to the Wall", (2, tt)))
+      :: (3, ("Restless and Wild", (2, tt)))
+      :: (4, ("Let There Be Rock", (1, tt)))
+      :: (5, ("Big Ones", (3, tt)))
+      :: (6, ("Jaggged Little Pill", (4, tt)))
+      :: (7, ("Facelift", (5, tt)))
+      :: nil
+      : list (interp_type album)
+           )).
+
+  Definition t := TPair "0" album (TPair "1" artist Unit).
+
+  (* SELECT * FROM albums JOIN artists WHERE album_id = id *)
+  Definition join_test := <{
+    "ans" <- flatmap (flatmap albums "y" (flatmap artists' "z" [("y", "z")])) "x" 
+    (if fst("x")["artist_id"] == snd("x")["id"] then ["x"] else nil[t])
+  }>.
+  Compute run_program ((("ans", (TList (t), true))) :: nil) join_test.
+
+  Definition tmp' : command := 
+    Eval cbv in match elaborate_command (map.of_list (("ans", (TList t, true))::nil)) join_test with
+    | Success x => x
+    | _ => _
+    end.
+  
+  Definition tmp := Eval cbv in match tmp' with
+                                | CGets _ e => e
+                                | _ => _
+                                end.
+  Compute tmp.
+  Compute flatmap_flatmap tmp.
+  Compute interp_expr map.empty tmp.
 
   Local Close Scope pylevel_scope.
 
-  Compute filter_test.
-  Compute run_program ((("ans", (TList artist, true)) :: nil)) filter_test.
+  Declare Scope query_sugar_scope.
+  Notation "'join' ( a : x ) ( b : y )" := 
+    (PEFlatmap a x%string (PEFlatmap b y%string (PEBinop POPair (PEVar x%string) (PEVar y%string))))
+    (at level 0, left associativity) : query_sugar_scope.
+
+  Declare Scope pretty_expr_scope.
+  Notation "[ e | x <- l ]" := (EFlatmap l x%string (EBinop (OCons _) e (EAtom (ANil _))))
+   (at level 10, only printing, left associativity) : pretty_expr_scope.
+
+  Notation "'nil'" := (EAtom (ANil _))
+    (at level 0, only printing) : pretty_expr_scope.
+
+  Notation "[ z ]" := (EBinop (OCons _) z (EAtom (ANil _)))
+   (at level 0, only printing) : pretty_expr_scope.
+
+  Notation "[ x , .. , y , z ]" := 
+    (EBinop (OCons _) x .. (EBinop (OCons _) y (EBinop (OCons _) z (EAtom (ANil _)))) ..)
+   (at level 110, only printing) : pretty_expr_scope.
+
+  Notation "{ x , .. , y , z }" := 
+    (EBinop (OPair _ _ _) x .. (EBinop (OPair _ _ _) y (EBinop (OPair _ _ _) z (EAtom AEmpty))) ..)
+   (at level 110, only printing) : pretty_expr_scope.
+
+  Declare Custom Entry pretty_record_fields.
+
+  Notation "{{ x }}" := x
+    (x custom pretty_record_fields at level 100, only printing) : pretty_expr_scope.
+
+  Notation "x : t , rest" := (TPair x t rest)
+    (in custom pretty_record_fields at level 100, x constr at level 0, t constr at level 0, right associativity, only printing) : pretty_expr_scope.
+
+  Notation "x : t" := (TPair x t TEmpty)
+    (in custom pretty_record_fields at level 100, x constr at level 0, t constr at level 0, only printing) : pretty_expr_scope.
+
+  Notation "{{}}" := TEmpty : pretty_expr_scope.
+
+  Notation "'<' x '>'" := (EAtom (_ x))
+   (at level 10, only printing, format "< x >") : pretty_expr_scope.
+
+  Notation "()" := (EAtom AEmpty)
+   (at level 10, only printing) : pretty_expr_scope.
+
+  Notation "$ x" := (EVar _ x%string)
+    (at level 10, only printing, format "$ x") : pretty_expr_scope.
+
+  Notation "'if' x 'then' y 'else' z" := (EIf x y z)
+    (at level 0, only printing) : pretty_expr_scope.
+
+  Notation "x == y" := (EBinop (OEq _ _) x y)
+    (at level 80, only printing) : pretty_expr_scope.
+
+  Notation "x [ k ]" := (EUnop (OFst k _ _) x)
+    (at level 10, only printing, left associativity) : pretty_expr_scope.
+
+  Notation "x" := (EUnop (OSnd _ _ _) x)
+    (at level 10, only printing, right associativity) : pretty_expr_scope.
+
+  Notation "[ x | x <- l , e ]" := 
+    (EFlatmap l x%string (EIf e (EBinop (OCons _) (EVar _ x%string) (EAtom (ANil _))) (EAtom (ANil _))))
+    (at level 10, only printing, l at level 9, x at level 0, e at level 10, left associativity) : pretty_expr_scope.
+
+  Local Open Scope pretty_expr_scope.
+  Compute tmp.
+  Compute partial (flatmap_singleton (flatmap_flatmap (flatmap_flatmap tmp))).
+  Local Close Scope pretty_expr_scope.
 
 End Queries_Section.


### PR DESCRIPTION
I have some comments briefly explaining what's wrong with `substitute` and what needs to be done to fix it.
Also added: improvements to unused name elimination (should be more aggressive now), printing notations for `expr` (in Queries.v), and example queries.