### PR TITLE
Support for let bindings in fiat2->bedrock2 expression compiler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ install_LiveVerif_noex:
 install_LiveVerif_ex:
 	$(MAKE) -C $(ABS_ROOT_DIR)/LiveVerif install_ex
 
-PyLevelLang: bedrock2_noex
+PyLevelLang: bedrock2_noex compiler_noex
 	$(MAKE) -C $(ABS_ROOT_DIR)/PyLevelLang
 
 clean_PyLevelLang:

--- a/PyLevelLang/Makefile
+++ b/PyLevelLang/Makefile
@@ -13,7 +13,7 @@ DEPS_DIR ?= ../deps
 # Note: make does not interpret "\n", and this is intended
 DEPFLAGS_COQUTIL_NL=-Q $(DEPS_DIR)/coqutil/src/coqutil coqutil\n
 DEPFLAGS_NL=
-CURFLAGS_NL=-Q ../bedrock2/src/bedrock2 bedrock2\n-Q src/PyLevelLang PyLevelLang\n
+CURFLAGS_NL=-Q ../bedrock2/src/bedrock2 bedrock2\n-Q ../compiler/src/compiler compiler\n-Q src/PyLevelLang PyLevelLang\n
 
 EXTERNAL_DEPENDENCIES?=
 EXTERNAL_COQUTIL?=

--- a/PyLevelLang/src/PyLevelLang/Compile.v
+++ b/PyLevelLang/src/PyLevelLang/Compile.v
@@ -7,6 +7,7 @@ Require Import coqutil.Datatypes.Result.
 Import ResultMonadNotations.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString coqutil.Map.MapEauto.
 Require Import coqutil.Byte coqutil.Word.Interface coqutil.Word.Bitwidth coqutil.Word.Properties.
+Require Import compiler.NameGen.
 
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.fwd.
@@ -76,37 +77,61 @@ Definition compile_binop {t1 t2 t3 : type} (o : binop t1 t2 t3) :
       error:("unimplemented")
   end.
 
-Fixpoint compile_expr {t : type} (e : expr t) : result (Syntax.cmd * Syntax.expr) :=
-  match e with
-  | EVar _ x | ELoc _ x =>
-      Success (Syntax.cmd.skip, Syntax.expr.var x)
-  | EAtom a =>
-      e' <- compile_atom a;;
-      Success (Syntax.cmd.skip, e')
-  | EUnop o e1 =>
-      f <- compile_unop o;;
-      '(c1, e1') <- compile_expr e1;;
-      Success (c1, f e1')
-  | EBinop o e1 e2 =>
-      f <- compile_binop o;;
-      '(c1, e1') <- compile_expr e1;;
-      '(c2, e2') <- compile_expr e2;;
-      Success (Syntax.cmd.seq c1 c2, f e1' e2')
-  | ELet x e1 e2 =>
-      '(c1, e1') <- compile_expr e1;;
-      '(c2, e2') <- compile_expr e2;;
-      Success (Syntax.cmd.seq c1 (Syntax.cmd.seq (Syntax.cmd.set x e1') c2), e2')
-  | _ => error:("unimplemented")
-  end.
+Section Map.
+  Context {key value : Type} {map : map.map key value} {map_ok : map.ok map}.
+  Definition map_values (m : map) : list value := map.fold (fun acc k v => cons v acc) nil m.
+End Map.
+
+Section NameGen.
+  Context {NGstate : Type}
+          {NG : NameGen string NGstate}
+          {namemap : map.map string string}
+          {namemap_ok : map.ok namemap}.
+
+  Fixpoint compile_expr {t : type} (e : expr t) (nm : namemap) (st : NGstate) :
+    result (Syntax.cmd * Syntax.expr * namemap * NGstate) :=
+    match e with
+    | EVar _ x | ELoc _ x =>
+        match map.get nm x with
+        | Some x' =>
+            Success (Syntax.cmd.skip, Syntax.expr.var x', nm, st)
+        | None =>
+            error:("variable x not mapped in target language (unreachable)")
+        end
+    | EAtom a =>
+        e' <- compile_atom a;;
+        Success (Syntax.cmd.skip, e', nm, st)
+    | EUnop o e1 =>
+        f <- compile_unop o;;
+        '(c1, e1', _, _) <- compile_expr e1 nm st;;
+        Success (c1, f e1', nm, st)
+    | EBinop o e1 e2 =>
+        f <- compile_binop o;;
+        '(c1, e1', _, _) <- compile_expr e1 nm st;;
+        '(c2, e2', _, _) <- compile_expr e2 nm st;;
+        Success (Syntax.cmd.seq c1 c2, f e1' e2', nm, st)
+    | ELet x e1 e2 =>
+        '(c1, e1', _, _) <- compile_expr e1 nm st;;
+        '(c2, e2', _, _) <- compile_expr e2 nm st;;
+        let '(x', st') := genFresh st in
+        let nm' := map.put nm x x' in
+        Success (Syntax.cmd.seq c1 (Syntax.cmd.seq (Syntax.cmd.set x' e1') c2), e2', nm', st')
+    | _ => error:("unimplemented")
+    end.
+End NameGen.
 
 Section WithMap.
-  Context {width: Z} {BW: Bitwidth width} {word: word.word width} {mem: map.map word byte}.
-  Context {word_ok: word.ok word} {mem_ok: map.ok mem}.
-  Context {tenv : map.map string (type * bool)} {tenv_ok : map.ok tenv}.
-  Context {locals: map.map string {t & interp_type (word := word) t}} {locals_ok: map.ok locals}.
-  Context {locals': map.map string word} {locals'_ok: map.ok locals'}.
-  Context {env: map.map String.string (list String.string * list String.string * Syntax.cmd)}.
-  Context {ext_spec: ExtSpec}.
+  Context {width : Z} {BW : Bitwidth width} {word : word.word width} {mem : map.map word byte}
+          {word_ok : word.ok word} {mem_ok : map.ok mem}
+          {tenv : map.map string (type * bool)} {tenv_ok : map.ok tenv}
+          {locals : map.map string {t & interp_type (word := word) t}} {locals_ok : map.ok locals}
+          {locals' : map.map string word} {locals'_ok : map.ok locals'}
+          {env : map.map String.string (list String.string * list String.string * Syntax.cmd)}
+          {ext_spec : ExtSpec}
+          {NGstate : Type}
+          {NG : NameGen string NGstate}
+          {namemap : map.map string string}
+          {namemap_ok : map.ok namemap}.
 
   (* Relation between source language and target language values,
    * denoting that two values are equivalent for a given type *)
@@ -124,64 +149,70 @@ Section WithMap.
   (* Relation between source language and target language locals maps,
    * denoting that the source language locals are a "subset" of the target
    * language locals *)
-  Definition locals_relation (lo : locals) (l : locals') : Prop :=
-    map.forall_keys (fun key =>
-    match map.get lo key with
-    | Some (existT _ _ val) => match map.get l key with
-                               | Some val' => value_relation val val'
-                               | None => False
-                               end
-    | None => True
+  Definition locals_relation (lo : locals) (l : locals') (nm : namemap) : Prop :=
+    map.forall_keys (fun x =>
+    match map.get lo x, map.get nm x with
+    | Some (existT _ _ val), Some x' =>
+        match map.get l x' with
+        | Some val' => value_relation val val'
+        | None => False
+        end
+    | _, _ => True
     end) lo.
 
-  Lemma locals_relation_extends (lo : locals) (l l' : locals') :
-    map.extends l' l -> locals_relation lo l -> locals_relation lo l'.
+  Lemma locals_relation_extends (lo : locals) (l l' : locals') (nm : namemap) :
+    map.extends l' l -> locals_relation lo l nm -> locals_relation lo l' nm.
   Proof.
-    intros Hex.
-    apply weaken_forall_keys.
-    intros key Hl.
-    destruct map.get as [s|]; try easy.
-    destruct s as [t val].
-    destruct (map.get l key) as [v|] eqn:E.
-    - apply (Properties.map.extends_get (m1 := l) (m2 := l')) in E;
-      [| assumption].
-      now rewrite E.
-    - destruct Hl.
-  Qed.
+  Admitted.
+  (*   intros Hex. *)
+  (*   apply weaken_forall_keys. *)
+  (*   intros key Hl. *)
+  (*   destruct map.get as [s|]; try easy. *)
+  (*   destruct s as [t val]. *)
+  (*   destruct (map.get l key) as [v|] eqn:E. *)
+  (*   - apply (Properties.map.extends_get (m1 := l) (m2 := l')) in E; *)
+  (*     [| assumption]. *)
+  (*     now rewrite E. *)
+  (*   - destruct Hl. *)
+  (* Qed. *)
 
-  Lemma locals_relation_get (lo : locals) (l : locals') :
-    locals_relation lo l ->
-    forall (x : string) (t : type) (s : {t & interp_type t}),
-    map.get lo x = Some s -> exists (w : word),
-    map.get l x = Some w.
+  Lemma locals_relation_get (lo : locals) (l : locals') (nm : namemap) :
+    locals_relation lo l nm ->
+    forall (x x' : string) (t : type) (s : {t & interp_type t}),
+    map.get lo x = Some s ->
+    map.get nm x = Some x' -> exists (w : word),
+    map.get l x' = Some w.
   Proof.
-    intros Hl x t s Hs.
-    unfold locals_relation, map.forall_keys in Hl.
-    specialize Hl with (1 := Hs).
-    rewrite Hs in Hl.
-    destruct map.get.
-    - now exists r.
-    - destruct s, Hl.
-  Qed.
+  Admitted.
+  (*   intros Hl x t s Hs. *)
+  (*   unfold locals_relation, map.forall_keys in Hl. *)
+  (*   specialize Hl with (1 := Hs). *)
+  (*   rewrite Hs in Hl. *)
+  (*   destruct map.get. *)
+  (*   - now exists r. *)
+  (*   - destruct s, Hl. *)
+  (* Qed. *)
 
-  Lemma locals_relation_put (lo : locals) (l : locals') :
-    locals_relation lo l ->
-    forall (x : string) (t : type) (v : interp_type t) (w : word),
+  Lemma locals_relation_put (lo : locals) (l : locals') (nm : namemap) :
+    locals_relation lo l nm ->
+    forall (x x' : string) (t : type) (v : interp_type t) (w : word),
     value_relation v w ->
-    locals_relation (set_local lo x v) (map.put l x w).
+    map.get nm x = Some x' ->
+    locals_relation (set_local lo x v) (map.put l x' w) nm.
   Proof.
-    intros Hl x t v w Hvw.
-    unfold locals_relation, map.forall_keys, set_local.
-    intros x' [t' v'].
-    repeat rewrite Properties.map.get_put_dec.
-    destruct (x =? x')%string.
-    - easy.
-    - intros Hx'. fwd.
-      unfold locals_relation, map.forall_keys in Hl.
-      specialize Hl with (1 := Hx').
-      rewrite Hx' in Hl.
-      assumption.
-  Qed.
+  Admitted.
+  (*   intros Hl x t v w Hvw. *)
+  (*   unfold locals_relation, map.forall_keys, set_local. *)
+  (*   intros x' [t' v']. *)
+  (*   repeat rewrite Properties.map.get_put_dec. *)
+  (*   destruct (x =? x')%string. *)
+  (*   - easy. *)
+  (*   - intros Hx'. fwd. *)
+  (*     unfold locals_relation, map.forall_keys in Hl. *)
+  (*     specialize Hl with (1 := Hx'). *)
+  (*     rewrite Hx' in Hl. *)
+  (*     assumption. *)
+  (* Qed. *)
 
   Definition tenv_relation (G : tenv) (lo : locals) : Prop :=
     map.forall_keys (fun key =>
@@ -292,13 +323,40 @@ Section WithMap.
         now rewrite H2.
   Qed.
 
+  (* Lemma compile_nm_extends : *)
+  (*   forall {t} (e : expr t) (c : Syntax.cmd) (e' : Syntax.expr) *)
+  (*   (nm nm' : namemap), *)
+  (*   compile_expr e nm = Success (c, e', nm') -> *)
+  (*   map.extends nm' nm. *)
+  (* Proof. *)
+  (*   intros t. induction e; intros c e' nm nm' He'; try easy. *)
+  (*   all: try (unfold compile_expr in He'; now fwd). *)
+  (*   unfold compile_expr in He'. *)
+  (*   fold (compile_expr (t := t1)) in He'. *)
+  (*   fold (compile_expr (t := t2)) in He'. *)
+  (*   fwd. *)
+  (*   unfold map.extends. *)
+  (*   intros x0 w Hw. *)
+  (*   rewrite Properties.map.get_put_dec. *)
+  (*   destruct (x =? x0)%string; [| assumption]. *)
+  (*   specialize genFresh_spec with (1 := E1) as H. *)
+
+  Lemma compile_locals_relation :
+    forall {t} (e : expr t) (c : Syntax.cmd) (e' : Syntax.expr)
+    (lo : locals) (l : locals') (nm nm' : namemap) (st st' : NGstate),
+    locals_relation lo l nm ->
+    compile_expr e nm st = Success (c, e', nm', st') ->
+    locals_relation lo l nm'.
+  Proof.
+  Admitted.
+
   Lemma compile_correct :
     forall {t} (e : expr t) (c : Syntax.cmd) (e' : Syntax.expr)
-    (G : tenv) (lo : locals),
+    (G : tenv) (lo : locals) (nm nm' : namemap) (st st' : NGstate),
     tenv_relation G lo ->
     wf G e ->
-    compile_expr e = Success (c, e') -> forall tr m l,
-    locals_relation lo l ->
+    compile_expr e nm st = Success (c, e', nm', st') -> forall tr m l,
+    locals_relation lo l nm ->
     exec map.empty c tr m l (fun tr' m' l' => exists (w : word),
       eval_expr m' l' e' = Some w /\
       value_relation (interp_expr lo e) w /\
@@ -306,24 +364,24 @@ Section WithMap.
       map.extends l' l
     ).
   Proof.
-    intros t. induction e; intros c e' G lo Hlo He He' tr m l Hl; try easy.
+    intros t. induction e; intros c e' G lo nm nm' st st' Hlo He He' tr m l Hl; try easy.
     1-2:
       (* EVar x, ELoc x *)
       unfold compile_expr in He';
       fwd;
       simpl;
+      rename s into x';
       apply exec.skip;
-      inversion He;
-      rename H2 into Hx;
-      destruct (tenv_relation_get _ lo Hlo _ _ _ Hx) as [v Hv];
-      destruct (locals_relation_get _ l Hl  _ t _ Hv) as [w Hw];
+      inversion_clear He;
+      destruct (tenv_relation_get _ lo Hlo _ _ _ H) as [v Hv];
+      destruct (locals_relation_get _ l _ Hl  _ x' t _ Hv) as [w Hw]; [easy |];
       exists w;
       ssplit; try easy;
       unfold get_local;
       rewrite Hv;
       unfold locals_relation, map.forall_keys in Hl;
       specialize Hl with (1 := Hv);
-      rewrite Hv, Hw in Hl;
+      rewrite Hv, E, Hw in Hl;
       now rewrite <- proj_expected_existT.
     - (* EAtom a *)
       unfold compile_expr in He'.
@@ -351,7 +409,7 @@ Section WithMap.
         fwd;
         inversion He;
         apply Eqdep_dec.inj_pair2_eq_dec in H4 as [= ->]; try exact type_eq_dec;
-        specialize IHe with (1 := Hlo) (3 := eq_refl) (4 := Hl);
+        specialize IHe with (1 := Hlo) (2 := H2) (3 := E);
         eapply exec.weaken; [ now apply IHe |];
         cbv beta;
         intros tr' m' l' Hw;
@@ -385,8 +443,8 @@ Section WithMap.
         apply Eqdep_dec.inj_pair2_eq_dec in H5 as [= ->]; try exact type_eq_dec;
         injection H6 as [= ->];
         apply Eqdep_dec.inj_pair2_eq_dec in H5 as [= ->]; try exact type_eq_dec;
-        specialize IHe1 with (1 := Hlo) (3 := eq_refl) (4 := Hl);
-        specialize IHe2 with (1 := Hlo) (3 := eq_refl);
+        specialize IHe1 with (1 := Hlo) (2 := H3) (3 := E);
+        specialize IHe2 with (1 := Hlo) (2 := H7) (3 := E0);
         eapply exec.seq; [ now apply IHe1 |];
         cbv beta;
         intros tr' m' l' Hw;
@@ -467,12 +525,14 @@ Section WithMap.
             now try rewrite word.unsigned_of_Z_1.
     - (* ELet x e1 e2 *)
       unfold compile_expr in He'.
-      fwd.
+      fold (compile_expr (t := t1)) in He'.
+      fold (compile_expr (t := t2)) in He'.
+      fwd;
+      rename e into e1', e' into e2';
+      rename c0 into c1, c1 into c2;
+      rename r into nm1, r0 into nm2;
+      rename s into x', E1 into En;
       rename E into E1, E0 into E2.
-      rename e into e1', e' into e2'.
-      rename c0 into c1, c1 into c2.
-      fold (compile_expr (t := t1)) in E1, IHe1.
-      fold (compile_expr (t := t2)) in E2, IHe2.
       inversion He;
       repeat lazymatch goal with
       | h: existT _ _ _ = existT _ _ _ |- _ =>
@@ -484,16 +544,16 @@ Section WithMap.
       eapply exec.seq.
       { apply IHe1 with (1 := Hlo) (2 := He1) (3 := E1) (4 := Hl). }
       cbv beta.
-      intros tr' m' l' mc' Hw.
+      intros tr' m' l' Hw.
       fwd.
 
-      apply exec.seq with (mid := fun tr'' m'' l'' mc''' => m'' = m /\ l'' = map.put l' x w).
+      apply exec.seq with (mid := fun tr'' m'' l'' => m'' = m /\ l'' = map.put l' x' w).
       {
         eapply exec.set.
         + exact Hwp0.
         + now split.
       }
-      intros tr'' m'' l'' mc''' Hw'.
+      intros tr'' m'' l'' Hw'.
       fwd.
       eassert (H : interp_expr lo (ELet x e1 e2) = interp_expr _ _) by now simpl.
       rewrite H. clear H.
@@ -502,18 +562,20 @@ Section WithMap.
       {
         apply IHe2 with (2 := He2) (3 := E2) (lo := (set_local lo x (interp_expr lo e1))).
         + now apply tenv_relation_put.
-        + apply locals_relation_put.
-          * now apply locals_relation_extends with l.
-          * assumption.
+        + admit.
+        (* + apply locals_relation_put. *)
+        (*   * now apply locals_relation_extends with l. *)
+        (*   * assumption. *)
+        (*   * *)
       }
       cbv beta.
-      intros tr''' m''' l''' mc'''' [w0 H].
+      intros tr''' m''' l''' [w0 H].
       fwd.
       exists w0. ssplit.
-      + now exists mc''0.
+      + easy.
       + exact Hp1.
       + reflexivity.
-      + apply extends_trans with (map.put l' x w). { assumption. }
+      + apply extends_trans with (map.put l' x' w). { assumption. }
         apply put_extends_l. 2: assumption.
         admit.
   Admitted.

--- a/PyLevelLang/src/PyLevelLang/Compile.v
+++ b/PyLevelLang/src/PyLevelLang/Compile.v
@@ -77,11 +77,6 @@ Definition compile_binop {t1 t2 t3 : type} (o : binop t1 t2 t3) :
       error:("unimplemented")
   end.
 
-Section Map.
-  Context {key value : Type} {map : map.map key value} {map_ok : map.ok map}.
-  Definition map_values (m : map) : list value := map.fold (fun acc k v => cons v acc) nil m.
-End Map.
-
 Section NameGen.
   Context {NGstate : Type}
           {NG : NameGen string NGstate}
@@ -96,7 +91,7 @@ Section NameGen.
         | Some x' =>
             Success (Syntax.cmd.skip, Syntax.expr.var x', nm, st)
         | None =>
-            error:("variable x not mapped in target language (unreachable)")
+            error:("variable" x "not mapped in target language (unreachable)")
         end
     | EAtom a =>
         e' <- compile_atom a;;

--- a/PyLevelLang/src/PyLevelLang/Compile.v
+++ b/PyLevelLang/src/PyLevelLang/Compile.v
@@ -7,7 +7,6 @@ Require Import coqutil.Datatypes.Result.
 Import ResultMonadNotations.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString coqutil.Map.MapEauto.
 Require Import coqutil.Byte coqutil.Word.Interface coqutil.Word.Bitwidth coqutil.Word.Properties.
-Require Import compiler.NameGen.
 
 Require Import coqutil.Tactics.Tactics.
 Require Import coqutil.Tactics.fwd.
@@ -32,7 +31,7 @@ Definition compile_unop {t1 t2 : type} (o : unop t1 t2) :
   | OFst _ _ _
   | OSnd _ _ _
   | OIntToString =>
-      error:("unimplemented")
+      error:("unsupported")
   end.
 
 Definition compile_binop {t1 t2 t3 : type} (o : binop t1 t2 t3) :
@@ -54,7 +53,7 @@ Definition compile_binop {t1 t2 t3 : type} (o : binop t1 t2 t3) :
       Success (Syntax.expr.op Syntax.bopname.or)
   | OConcat _
   | OConcatString =>
-      error:("unimplemented")
+      error:("unsupported")
   | OWLessU =>
       Success (Syntax.expr.op Syntax.bopname.ltu)
   | OWLessS =>
@@ -74,46 +73,26 @@ Definition compile_binop {t1 t2 t3 : type} (o : binop t1 t2 t3) :
   | OCons _
   | ORange
   | OWRange =>
-      error:("unimplemented")
+      error:("unsupported")
   end.
 
-Section NameGen.
-  Context {NGstate : Type}
-          {NG : NameGen string NGstate}
-          {namemap : map.map string string}
-          {namemap_ok : map.ok namemap}.
-
-  Fixpoint compile_expr {t : type} (e : expr t) (nm : namemap) (st : NGstate) :
-    result (Syntax.cmd * Syntax.expr * namemap * NGstate) :=
-    match e with
-    | EVar _ x | ELoc _ x =>
-        match map.get nm x with
-        | Some x' =>
-            Success (Syntax.cmd.skip, Syntax.expr.var x', nm, st)
-        | None =>
-            error:("variable" x "not mapped in target language (unreachable)")
-        end
-    | EAtom a =>
-        e' <- compile_atom a;;
-        Success (Syntax.cmd.skip, e', nm, st)
-    | EUnop o e1 =>
-        f <- compile_unop o;;
-        '(c1, e1', _, _) <- compile_expr e1 nm st;;
-        Success (c1, f e1', nm, st)
-    | EBinop o e1 e2 =>
-        f <- compile_binop o;;
-        '(c1, e1', _, _) <- compile_expr e1 nm st;;
-        '(c2, e2', _, _) <- compile_expr e2 nm st;;
-        Success (Syntax.cmd.seq c1 c2, f e1' e2', nm, st)
-    | ELet x e1 e2 =>
-        '(c1, e1', _, _) <- compile_expr e1 nm st;;
-        '(c2, e2', _, _) <- compile_expr e2 nm st;;
-        let '(x', st') := genFresh st in
-        let nm' := map.put nm x x' in
-        Success (Syntax.cmd.seq c1 (Syntax.cmd.seq (Syntax.cmd.set x' e1') c2), e2', nm', st')
-    | _ => error:("unimplemented")
-    end.
-End NameGen.
+Fixpoint compile_expr {t : type} (e : expr t) : result Syntax.expr :=
+  match e with
+  | EVar _ x | ELoc _ x =>
+      Success (Syntax.expr.var x)
+  | EAtom a =>
+      compile_atom a
+  | EUnop o e1 =>
+      f <- compile_unop o;;
+      e1' <- compile_expr e1;;
+      Success (f e1')
+  | EBinop o e1 e2 =>
+      f <- compile_binop o;;
+      e1' <- compile_expr e1;;
+      e2' <- compile_expr e2;;
+      Success (f e1' e2')
+  | _ => error:("unsupported")
+  end.
 
 Section WithMap.
   Context {width : Z} {BW : Bitwidth width} {word : word.word width} {mem : map.map word byte}
@@ -122,11 +101,7 @@ Section WithMap.
           {locals : map.map string {t & interp_type (word := word) t}} {locals_ok : map.ok locals}
           {locals' : map.map string word} {locals'_ok : map.ok locals'}
           {env : map.map String.string (list String.string * list String.string * Syntax.cmd)}
-          {ext_spec : ExtSpec}
-          {NGstate : Type}
-          {NG : NameGen string NGstate}
-          {namemap : map.map string string}
-          {namemap_ok : map.ok namemap}.
+          {ext_spec : ExtSpec}.
 
   (* Relation between source language and target language values,
    * denoting that two values are equivalent for a given type *)
@@ -144,69 +119,65 @@ Section WithMap.
   (* Relation between source language and target language locals maps,
    * denoting that the source language locals are a "subset" of the target
    * language locals *)
-  Definition locals_relation (lo : locals) (l : locals') (nm : namemap) : Prop :=
+  Definition locals_relation (lo : locals) (l : locals') : Prop :=
     map.forall_keys (fun x =>
-    match map.get lo x, map.get nm x with
-    | Some (existT _ _ val), Some x' =>
-        match map.get l x' with
+    match map.get lo x with
+    | Some (existT _ _ val) =>
+        match map.get l x with
         | Some val' => value_relation val val'
         | None => False
         end
-    | _, _ => True
+    | _ => True
     end) lo.
 
-  Lemma locals_relation_extends (lo : locals) (l l' : locals') (nm : namemap) :
-    map.extends l' l -> locals_relation lo l nm -> locals_relation lo l' nm.
+  Lemma locals_relation_extends (lo : locals) (l l' : locals') :
+    map.extends l' l -> locals_relation lo l -> locals_relation lo l'.
   Proof.
     intros Hex.
     apply weaken_forall_keys.
-    intros key Hl.
+    intros x Hl.
     destruct map.get as [s|]; try easy.
     destruct s as [t val].
-    destruct (map.get nm key) as [x'|]; try easy.
-    destruct (map.get l x') as [v|] eqn:E.
+    destruct (map.get l x) as [v|] eqn:E.
     - apply (Properties.map.extends_get (m1 := l) (m2 := l')) in E;
       [| assumption].
       now rewrite E.
     - destruct Hl.
   Qed.
 
-  Lemma locals_relation_get (lo : locals) (l : locals') (nm : namemap) :
-    locals_relation lo l nm ->
-    forall (x x' : string) (t : type) (s : {t & interp_type t}),
-    map.get lo x = Some s ->
-    map.get nm x = Some x' -> exists (w : word),
-    map.get l x' = Some w.
+  Lemma locals_relation_get (lo : locals) (l : locals') :
+    locals_relation lo l ->
+    forall (x : string) (t : type) (s : {t & interp_type t}),
+    map.get lo x = Some s -> exists (w : word),
+    map.get l x = Some w.
   Proof.
-    intros Hl x x' t s Hs Hx'.
+    intros Hl x t s Hs.
     unfold locals_relation, map.forall_keys in Hl.
     specialize Hl with (1 := Hs).
     rewrite Hs in Hl.
     destruct map.get.
     - fwd. now exists r.
-    - discriminate Hx'.
+    - destruct s, Hl.
   Qed.
 
-  Lemma locals_relation_put (lo : locals) (l : locals') (nm : namemap) :
-    locals_relation lo l nm ->
-    forall (x x' : string) (t : type) (v : interp_type t) (w : word),
+  Lemma locals_relation_put (lo : locals) (l : locals') :
+    locals_relation lo l ->
+    forall (x : string) (t : type) (v : interp_type t) (w : word),
     value_relation v w ->
-    map.get nm x = Some x' ->
-    locals_relation (set_local lo x v) (map.put l x' w) nm.
+    locals_relation (set_local lo x v) (map.put l x w).
   Proof.
-  Admitted.
-  (*   intros Hl x t v w Hvw. *)
-  (*   unfold locals_relation, map.forall_keys, set_local. *)
-  (*   intros x' [t' v']. *)
-  (*   repeat rewrite Properties.map.get_put_dec. *)
-  (*   destruct (x =? x')%string. *)
-  (*   - easy. *)
-  (*   - intros Hx'. fwd. *)
-  (*     unfold locals_relation, map.forall_keys in Hl. *)
-  (*     specialize Hl with (1 := Hx'). *)
-  (*     rewrite Hx' in Hl. *)
-  (*     assumption. *)
-  (* Qed. *)
+    intros Hl x t v w Hvw.
+    unfold locals_relation, map.forall_keys, set_local.
+    intros x' [t' v'].
+    repeat rewrite Properties.map.get_put_dec.
+    destruct (x =? x')%string.
+    - easy.
+    - intros Hx'. fwd.
+      unfold locals_relation, map.forall_keys in Hl.
+      specialize Hl with (1 := Hx').
+      rewrite Hx' in Hl.
+      assumption.
+  Qed.
 
   Definition tenv_relation (G : tenv) (lo : locals) : Prop :=
     map.forall_keys (fun key =>
@@ -317,81 +288,73 @@ Section WithMap.
         now rewrite H2.
   Qed.
 
+  Compute (compile_expr (EBinop (OEq _ _) (EAtom (ABool true)) (EAtom (ABool false)))).
+
   Lemma compile_correct :
-    forall {t} (e : expr t) (c : Syntax.cmd) (e' : Syntax.expr)
-    (G : tenv) (lo : locals) (nm nm' : namemap) (st st' : NGstate),
-    tenv_relation G lo ->
+    forall {t} (e : expr t) (e' : Syntax.expr) (G : tenv),
     wf G e ->
-    compile_expr e nm st = Success (c, e', nm', st') -> forall tr m l,
-    locals_relation lo l nm ->
-    locals_relation lo l nm' /\
-    exec map.empty c tr m l (fun tr' m' l' => exists (w : word),
-      eval_expr m' l' e' = Some w /\
-      value_relation (interp_expr lo e) w /\
-      m' = m /\
-      map.extends l' l
-    ).
+    compile_expr e = Success e' -> forall lo l,
+    tenv_relation G lo ->
+    locals_relation lo l -> exists w : word, forall m,
+    eval_expr m l e' = Some w /\
+    value_relation (interp_expr lo e) w.
   Proof.
-    intros t. induction e; intros c e' G lo nm nm' st st' Hlo He He' tr m l Hl; try easy.
+    intros t. induction e; intros e' G He He' lo l Hlo Hl; try easy.
     1-2:
       (* EVar x, ELoc x *)
       unfold compile_expr in He';
       fwd;
       simpl;
-      rename s into x';
-      split; [easy |];
-      apply exec.skip;
       inversion_clear He;
       destruct (tenv_relation_get _ lo Hlo _ _ _ H) as [v Hv];
-      destruct (locals_relation_get _ l _ Hl  _ x' t _ Hv) as [w Hw]; [easy |];
+      destruct (locals_relation_get _ l Hl x t _ Hv) as [w Hw];
       exists w;
-      ssplit; try easy;
+      intros m; ssplit; try easy;
       unfold get_local;
       rewrite Hv;
       unfold locals_relation, map.forall_keys in Hl;
       specialize Hl with (1 := Hv);
-      rewrite Hv, E, Hw in Hl;
+      rewrite Hv, Hw in Hl;
       now rewrite <- proj_expected_existT.
     - (* EAtom a *)
       unfold compile_expr in He'.
       fwd.
-      split; [easy |].
-      apply exec.skip.
+      simpl.
       destruct a; try easy.
       + (* AInt n *)
-        injection E as [= <-].
         simpl.
+        simpl in He'.
+        fwd.
         exists (word.of_Z (word.wrap n)).
-        ssplit; try easy;
+        intros m; ssplit;
         rewrite <- word.unsigned_of_Z, word.of_Z_unsigned; try easy.
         apply RWord.
       + (* ABool b *)
-        injection E as [= <-].
         simpl.
+        simpl in He'.
+        fwd.
         exists (word.of_Z (Z.b2z b)).
-        ssplit; try easy.
+        intros m; ssplit; try easy.
         apply RBool.
     - (* EUnop o e *)
       destruct o; try easy.
       all:
-        simpl in He';
         simpl;
-        fwd;
+        simpl in He';
+        fwd; rename a into e', E into He';
         inversion He;
-        apply Eqdep_dec.inj_pair2_eq_dec in H4 as [= ->]; try exact type_eq_dec;
-        specialize IHe with (1 := Hlo) (2 := H2) (3 := E);
-        split; [easy |];
-        eapply exec.weaken; [ now apply IHe |];
-        cbv beta;
-        intros tr' m' l' Hw;
+        apply Eqdep_dec.inj_pair2_eq_dec in H3, H4 as [= ->]; try exact type_eq_dec;
+        apply Eqdep_dec.inj_pair2_eq_dec in H3 as [= ->]; try exact type_eq_dec;
+        subst;
+        specialize IHe with (1 := H2) (2 := eq_refl) (3 := Hlo) (4 := Hl);
         fwd;
         eexists;
-        ssplit;
-        [ simpl; now fwd
-        |
-        | reflexivity
-        | assumption ];
-        inversion Hwp1;
+        intros m; specialize IHe with m; fwd;
+        simpl;
+        rewrite IHep0;
+        split;
+        [ reflexivity |];
+        inversion IHep1;
         subst;
         repeat (repeat lazymatch goal with
         | h: existT _ _ _ = existT _ _ _ |- _ =>
@@ -407,44 +370,33 @@ Section WithMap.
     - (* EBinop o e1 e2 *)
       destruct o; try easy.
       all:
-        simpl in He';
         simpl;
-        fwd;
+        simpl in He';
+        fwd; rename a into e1', E into He1', a0 into e2', E0 into He2';
         inversion He;
-        apply Eqdep_dec.inj_pair2_eq_dec in H5 as [= ->]; try exact type_eq_dec;
-        injection H6 as [= ->];
-        apply Eqdep_dec.inj_pair2_eq_dec in H5 as [= ->]; try exact type_eq_dec;
-        specialize IHe1 with (1 := Hlo) (2 := H3) (3 := E);
-        specialize IHe2 with (1 := Hlo) (2 := H7) (3 := E0);
-        split; [easy |];
-        eapply exec.seq; [ now apply IHe1 |];
-        cbv beta;
-        intros tr' m' l' Hw;
-        fwd;
-        eapply exec.weaken; [
-          apply IHe2;
-          assumption || now apply locals_relation_extends with (l := l)
-        |];
-        cbv beta;
-        intros tr'' m'' l'' Hw';
-        fwd;
-        eexists;
-        ssplit;
-        [ simpl; fwd;
-          apply eval_map_extends_locals with (l' := l'') in Hwp0;
-          [| assumption];
-          now rewrite Hwp0
-        |
-        | reflexivity
-        | now apply extends_trans with l' ].
-      1-9:
-        inversion Hwp1; inversion Hw'p1;
-        subst;
-        repeat lazymatch goal with
+        repeat (repeat lazymatch goal with
         | h: existT _ _ _ = existT _ _ _ |- _ =>
             apply interp_type_eq in h
         end;
+        subst);
+        apply Eqdep_dec.inj_pair2_eq_dec in H5, H6 as [= ->]; try exact type_eq_dec;
         subst;
+        specialize IHe1 with (1 := H3) (2 := eq_refl) (3 := Hlo) (4 := Hl);
+        specialize IHe2 with (1 := H7) (2 := eq_refl) (3 := Hlo) (4 := Hl);
+        fwd;
+        eexists;
+        intros m; specialize IHe1 with m; specialize IHe2 with m; fwd;
+        simpl;
+        rewrite IHe1p0, IHe2p0;
+        split;
+        [ reflexivity |];
+        inversion IHe1p1; inversion IHe2p1;
+        subst;
+        repeat (repeat lazymatch goal with
+        | h: existT _ _ _ = existT _ _ _ |- _ =>
+            apply interp_type_eq in h
+        end;
+        subst);
         set (v1 := interp_expr _ e1);
         set (v2 := interp_expr _ e2).
       1-5:
@@ -467,7 +419,37 @@ Section WithMap.
       + (* OWLessS *)
         destruct (word.lts v1 v2);
         apply RBool.
-      + (* OEq *)
+      + (* OEq TWord _ *)
+        unfold eqb_values.
+        inversion IHe1p1; inversion IHe2p1.
+        subst.
+        repeat (repeat lazymatch goal with
+        | h: existT _ _ _ = existT _ _ _ |- _ =>
+            apply interp_type_eq in h
+        end;
+        subst).
+        destruct (word.eqb _ _);
+        apply RBool.
+      + (* NOT OEq TBool _ *)
+        unfold eqb_values.
+        inversion IHe1p1; inversion IHe2p1.
+        subst.
+        repeat (repeat lazymatch goal with
+        | h: existT _ _ _ = existT _ _ _ |- _ =>
+            apply interp_type_eq in h
+        end;
+        subst).
+        rewrite <- H8.
+          set (b1 := interp_expr _ e1).
+          set (b2 := interp_expr _ e2).
+          destruct b1, b2.
+          (* all: *)
+          (*   apply RBool'; *)
+          (*   simpl; *)
+          (*   rewrite word.unsigned_eqb; *)
+          (*   try rewrite word.unsigned_of_Z_0; *)
+          (*   now try rewrite word.unsigned_of_Z_1. *)
+          
         destruct t;
         try easy; unfold eqb_values.
         * (* TWord *)
@@ -495,60 +477,10 @@ Section WithMap.
             rewrite word.unsigned_eqb;
             try rewrite word.unsigned_of_Z_0;
             now try rewrite word.unsigned_of_Z_1.
-    - (* ELet x e1 e2 *)
-      unfold compile_expr in He'.
-      fold (compile_expr (t := t1)) in He'.
-      fold (compile_expr (t := t2)) in He'.
-      fwd;
-      rename e into e1', e' into e2';
-      rename c0 into c1, c1 into c2;
-      rename r into nm1, r0 into nm2;
-      rename s into x', E1 into En;
-      rename E into E1, E0 into E2.
-      inversion He;
-      repeat lazymatch goal with
-      | h: existT _ _ _ = existT _ _ _ |- _ =>
-          apply Eqdep_dec.inj_pair2_eq_dec in h as [= ->]; try exact type_eq_dec
-      end;
-      subst;
-      rename H4 into He1, H6 into He2.
-      split.
-      { admit. }
+      + 
 
-      eapply exec.seq.
-      { apply IHe1 with (1 := Hlo) (2 := He1) (3 := E1) (4 := Hl). }
-      cbv beta.
-      intros tr' m' l' Hw.
-      fwd.
 
-      apply exec.seq with (mid := fun tr'' m'' l'' => m'' = m /\ l'' = map.put l' x' w).
-      {
-        eapply exec.set.
-        + exact Hwp0.
-        + now split.
-      }
-      intros tr'' m'' l'' Hw'.
-      fwd.
-      eassert (H : interp_expr lo (ELet x e1 e2) = interp_expr _ _) by now simpl.
-      rewrite H. clear H.
-
-      eapply exec.weaken.
-      {
-        apply IHe2 with (2 := He2) (3 := E2) (lo := (set_local lo x (interp_expr lo e1))).
-        + now apply tenv_relation_put.
-        + admit.
-      }
-      cbv beta.
-      intros tr''' m''' l''' [w0 H].
-      fwd.
-      exists w0. ssplit.
-      + easy.
-      + exact Hp1.
-      + reflexivity.
-      + apply extends_trans with (map.put l' x' w). { assumption. }
-        apply put_extends_l. 2: assumption.
-        admit.
-  Admitted.
+  Qed.
 
 End WithMap.
 

--- a/PyLevelLang/src/PyLevelLang/Compile.v
+++ b/PyLevelLang/src/PyLevelLang/Compile.v
@@ -516,7 +516,7 @@ Section WithMap.
           apply Eqdep_dec.inj_pair2_eq_dec in h as [= ->]; try exact type_eq_dec
       end;
       subst;
-      rename H3 into He1, H6 into He2.
+      rename H4 into He1, H6 into He2.
       split.
       { admit. }
 

--- a/PyLevelLang/src/PyLevelLang/Compile.v
+++ b/PyLevelLang/src/PyLevelLang/Compile.v
@@ -191,7 +191,9 @@ Section WithMap.
     simpl.
     case type_eq_dec eqn:E; [| easy].
     unfold cast.
-  Admitted.
+    rewrite (Eqdep_dec.UIP_dec type_eq_dec e eq_refl).
+    trivial.
+  Qed.
 
   Lemma interp_type_eq : forall {t : type} (e : expr t) (w : interp_type t) (l : locals),
     (existT interp_type t w =

--- a/PyLevelLang/src/PyLevelLang/Elaborate.v
+++ b/PyLevelLang/src/PyLevelLang/Elaborate.v
@@ -2,6 +2,7 @@ Require Import PyLevelLang.Language.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString.
 Require Import coqutil.Datatypes.Result.
 Import ResultMonadNotations.
+Require Import compiler.NameGen.
 
 (* Casts an expression `e` from `expr t2` to `expr t1`, if the two types are
    equal *)
@@ -34,10 +35,14 @@ Qed.
 Section WithMap.
   (* abstract all functions in this section over the implementation of the map,
      and over its spec (map.ok) *)
-  Context {tenv : map.map string (type * bool)} {tenv_ok : map.ok tenv}.
+  Context {tenv : map.map string (type * bool)} {tenv_ok : map.ok tenv}
+          {namemap : map.map string string}
+          {namemap_ok : map.ok namemap}
+          {NGstate : Type}
+          {NG : NameGen string NGstate}.
 
   (* Well-formedness judgement for `expr`s, stating that an `expr` has no free
-   * variables and variables are used with correct types *)
+   * variables, variables are used with correct types, and no shadowing occurs *)
   Inductive wf : tenv -> forall {t : type}, expr t -> Prop :=
     | wf_EVar G t (x : string) :
         map.get G x = Some (t, false) -> wf G (EVar t x)
@@ -51,14 +56,21 @@ Section WithMap.
         wf G e1 -> wf G e2 -> wf G (EBinop o e1 e2)
     | wf_EFlatmap G {t1 t2} (e1 : expr (TList t1)) (x : string)
         (e2 : expr (TList t2)) :
-        wf G e1 -> wf (map.put G x (t1, false)) e2 -> wf G (EFlatmap e1 x e2)
-    | wf_EFold G {t1 t2} (e1 : expr (TList t1)) (e2 : expr t2) (x : string) 
+        wf G e1 -> wf (map.put G x (t1, false)) e2 ->
+        map.get G x = None ->
+        wf G (EFlatmap e1 x e2)
+    | wf_EFold G {t1 t2} (e1 : expr (TList t1)) (e2 : expr t2) (x : string)
         (y : string) (e3 : expr t2) :
-        wf G e1 -> wf G e2 -> wf (map.put (map.put G x (t1, false)) y (t2, false)) e3 -> wf G (EFold e1 e2 x y e3)
+        wf G e1 -> wf G e2 ->
+        wf (map.put (map.put G x (t1, false)) y (t2, false)) e3 ->
+        map.get G x = None -> map.get G y = None ->
+        wf G (EFold e1 e2 x y e3)
     | wf_EIf G {t} (e1 : expr TBool) (e2 e3 : expr t) :
         wf G e1 -> wf G e2 -> wf G e3 -> wf G (EIf e1 e2 e3)
     | wf_ELet G {t1 t2} (x : string) (e1 : expr t1) (e2 : expr t2) :
-        wf G e1 -> wf (map.put G x (t1, false)) e2 -> wf G (ELet x e1 e2).
+        wf G e1 -> wf (map.put G x (t1, false)) e2 ->
+        map.get G x = None ->
+        wf G (ELet x e1 e2).
 
   (* Same, but for commands *)
   Inductive wf_command : tenv -> command -> Prop :=
@@ -67,9 +79,11 @@ Section WithMap.
         wf_command G c1 -> wf_command G c2 -> wf_command G (CSeq c1 c2)
     | wf_CLet G {t} (x : string) (e : expr t) (c : command) :
         wf G e -> wf_command (map.put G x (t, false)) c ->
+        map.get G x = None ->
         wf_command G (CLet x e c)
     | wf_CLetMut G {t} (x : string) (e : expr t) (c : command) :
         wf G e -> wf_command (map.put G x (t, true)) c ->
+        map.get G x = None ->
         wf_command G (CLetMut x e c)
     | wf_CGets G {t} (x : string) (e : expr t) :
         wf G e -> map.get G x = Some (t, true) -> wf_command G (CGets x e)
@@ -78,6 +92,7 @@ Section WithMap.
         wf_command G (CIf e c1 c2)
     | wf_CForeach G {t} (x : string) (e : expr (TList t)) (c : command) :
         wf G e -> wf_command (map.put G x (t, false)) c ->
+        map.get G x = None ->
         wf_command G (CForeach x e c).
 
   (* `enforce_type` preserves well-formedness *)
@@ -149,7 +164,7 @@ Section WithMap.
     intros G t0 e0 He H.
     destruct po; unfold elaborate_unop in H.
     all: try (
-      destruct (enforce_type _ e) as [e' |] eqn : H'; try easy;
+      destruct (enforce_type _ e) as [e' |] eqn:H'; try easy;
       inversion H;
       apply wf_EUnop; now apply enforce_type_wf with (G := G) in H'
     ).
@@ -176,7 +191,7 @@ Section WithMap.
 
   Definition construct_eq {t: type} (e1 e2 : expr t) : result {t & expr t}.
   Proof.
-    destruct (can_eq t) eqn : H.
+    destruct (can_eq t) eqn:H.
     - pose (e := construct_eq' e1 e2).
       rewrite H in e.
       exact (Success (existT _ _ e)).
@@ -322,14 +337,14 @@ Section WithMap.
     intros G t0 e0 H1 H2 H.
     destruct po; unfold elaborate_binop in H.
     all: try (
-      destruct (enforce_type _ e1) as [e1' |] eqn : H1'; try easy;
-      destruct (enforce_type _ e2) as [e2' |] eqn : H2'; try easy;
+      destruct (enforce_type _ e1) as [e1' |] eqn:H1'; try easy;
+      destruct (enforce_type _ e2) as [e2' |] eqn:H2'; try easy;
       inversion H;
       apply wf_EBinop; now apply enforce_type_wf with (G := G) in H1', H2'
     ).
     all: try (
       destruct t1; try easy;
-      destruct (enforce_type _ e2) as [e2' |] eqn : H2'; try easy;
+      destruct (enforce_type _ e2) as [e2' |] eqn:H2'; try easy;
       inversion H;
       apply wf_EBinop; now apply enforce_type_wf with (G := G) in H2'
     ).
@@ -366,92 +381,111 @@ Section WithMap.
   Qed.
 
   Section ElaborateRecord.
-    Context (elaborate : tenv -> pexpr -> result {t & expr t}).
+    Context (elaborate : namemap -> tenv -> pexpr -> result {t & expr t}).
 
-    Fixpoint elaborate_record (G : tenv) (xs : list (string * pexpr)) :
-      result {t & expr t} :=
+    Fixpoint elaborate_record (nm : namemap) (G : tenv)
+      (xs : list (string * pexpr)) : result {t & expr t} :=
       match xs with
       | nil =>
           Success (existT _ _ (EAtom AEmpty))
       | (s, p) :: xs =>
-          '(existT _ _ e1) <- elaborate G p;;
-          '(existT _ _ e2) <- elaborate_record G xs;;
+          '(existT _ _ e1) <- elaborate nm G p;;
+          '(existT _ _ e2) <- elaborate_record nm G xs;;
           Success (existT _ _ (EBinop (OPair s _ _) e1 e2))
       end.
   End ElaborateRecord.
 
-  (* Type checks a `pexpr` and possibly emits a typed expression
-     Checks scoping for variables/locations *)
-  Fixpoint elaborate (G : tenv) (p : pexpr) : result {t & expr t} :=
+  Definition tenv_fresh (G : tenv) : string :=
+    fst (genFresh (freshNameGenState (map.keys G))).
+
+  (* Type checks a `pexpr` and possibly emits a well-formed typed expression.
+     Checks scoping for variables/locations, and renames variables to avoid
+     shadowing *)
+  Fixpoint elaborate (nm : namemap) (G : tenv) (p : pexpr) :
+    result ({t & expr t}) :=
     match p with
     | PEVar x =>
-        match map.get G x with
-        | Some (t, false) =>
-            Success (existT _ _ (EVar t x))
-        | Some (t, true) =>
-            Success (existT _ _ (ELoc t x))
+        match map.get nm x with
+        | Some x' =>
+            match map.get G x' with
+            | Some (t, false) =>
+                Success (existT _ _ (EVar t x'))
+            | Some (t, true) =>
+                Success (existT _ _ (ELoc t x'))
+            | None => error:("Undefined variable" x)
+            end
         | None => error:("Undefined variable" x)
         end
     | PEAtom pa =>
         elaborate_atom pa
-    | PESingleton p' =>
-        '(existT _ t' e') <- elaborate G p';;
-        Success (existT _ _ (EBinop (OCons _) e' (EAtom (ANil t'))))
+    | PESingleton p =>
+        '(existT _ t e) <- elaborate nm G p;;
+        Success (existT _ _ (EBinop (OCons _) e (EAtom (ANil t))))
     | PEUnop po p =>
-        '(existT _ t e) <- elaborate G p;;
+        '(existT _ t e) <- elaborate nm G p;;
         elaborate_unop po e
     | PEBinop po p1 p2 =>
-        '(existT _ t1 e1) <- elaborate G p1;;
-        '(existT _ t2 e2) <- elaborate G p2;;
+        '(existT _ t1 e1) <- elaborate nm G p1;;
+        '(existT _ t2 e2) <- elaborate nm G p2;;
         elaborate_binop po e1 e2
     | PEFlatmap p1 x p2 =>
-        '(existT _ t1 e1) <- elaborate G p1;;
+        '(existT _ t1 e1) <- elaborate nm G p1;;
         match t1 as t' return expr t' -> _ with
         | TList t1 => fun e1 =>
-            let G' := map.put G x (t1, false) in
-            '(existT _ t2 e2) <- elaborate G' p2;;
+            let x' := tenv_fresh G in
+            let nm' := map.put nm x x' in
+            let G' := map.put G x' (t1, false) in
+            '(existT _ t2 e2) <- elaborate nm' G' p2;;
             match t2 as t' return expr t' -> _ with
-            | TList t2 => fun e2 => Success (existT _ _ (EFlatmap e1 x e2))
+            | TList t2 => fun e2 => Success (existT _ _ (EFlatmap e1 x' e2))
             | _ => fun _ => error:(e2 "has type" t2 "but expected" TList)
             end e2
         | _ => fun _ => error:(e1 "has type" t1 "but expected" TList)
         end e1
     | PEFold p1 p2 x y p3 =>
-        '(existT _ t1 e1) <- elaborate G p1;;
+        '(existT _ t1 e1) <- elaborate nm G p1;;
         match t1 as t' return expr t' -> _ with
         | TList t1 => fun e1 => 
-            '(existT _ t2 e2) <- elaborate G p2;;
-            let G' := map.put (map.put G x (t1, false)) y (t2, false) in
-            '(existT _ t3 e3) <- elaborate G' p3;;
+            '(existT _ t2 e2) <- elaborate nm G p2;;
+            let x' := tenv_fresh G in
+            let nm' := map.put nm x x' in
+            let G' := map.put G x' (t1, false) in
+            let y' := tenv_fresh G' in
+            let nm'' := map.put nm' y y' in
+            let G'' := map.put G' y' (t2, false) in
+            '(existT _ t3 e3) <- elaborate nm'' G'' p3;;
             e3' <- enforce_type t2 e3;;
-            Success (existT _ _ (EFold e1 e2 x y e3'))
+            Success (existT _ _ (EFold e1 e2 x' y' e3'))
         | _ => fun _ => error:(e1 "has type" t1 "but expected" TList)
         end e1
     | PEIf p1 p2 p3 =>
-        '(existT _ t1 e1) <- elaborate G p1;;
-        '(existT _ t2 e2) <- elaborate G p2;;
-        '(existT _ t3 e3) <- elaborate G p3;;
+        '(existT _ t1 e1) <- elaborate nm G p1;;
+        '(existT _ t2 e2) <- elaborate nm G p2;;
+        '(existT _ t3 e3) <- elaborate nm G p3;;
         e1' <- enforce_type TBool e1;;
         e3' <- enforce_type t2 e3;;
         Success (existT _ _ (EIf e1' e2 e3'))
     | PELet x p1 p2 =>
-        '(existT _ t1 e1) <- elaborate G p1;;
-        let G' := map.put G x (t1, false) in
-        '(existT _ t2 e2) <- elaborate G' p2;;
-        Success (existT _ _ (ELet x e1 e2))
+        '(existT _ t1 e1) <- elaborate nm G p1;;
+        let x' := tenv_fresh G in
+        let nm' := map.put nm x x' in
+        let G' := map.put G x' (t1, false) in
+        '(existT _ t2 e2) <- elaborate nm' G' p2;;
+        Success (existT _ _ (ELet x' e1 e2))
     | PERecord ps =>
-        elaborate_record elaborate G ps
+        elaborate_record elaborate nm G ps
     | PEProj p s =>
-      '(existT _ t e) <- elaborate G p;;
+        '(existT _ t e) <- elaborate nm G p;;
         elaborate_proj e s
     end.
 
-  Fixpoint elaborate_wf (p : pexpr) : forall G t e,
-    elaborate G p = Success (existT expr t e) -> wf G e.
+  Fixpoint elaborate_wf (p : pexpr) : forall nm G t e,
+    elaborate nm G p = Success (existT expr t e) -> wf G e.
   Proof.
-    induction p; intros G t e H; unfold elaborate in H; fold elaborate in H.
+    induction p; intros nm G t e H; unfold elaborate in H; fold elaborate in H.
     - (* PEVar x *)
-      destruct (map.get G x) as [[t' [|]] |] eqn : Hmap.
+      destruct (map.get nm x) as [x' |] eqn:Hx'; try easy.
+      destruct (map.get G x') as [[t' [|]] |] eqn:Hmap.
       + (* Some (t', true) *)
         injection H as [= H' H]. rewrite H' in H.
         injection H as H.
@@ -466,77 +500,94 @@ Section WithMap.
     - (* PEAtom pa *)
       now apply elaborate_atom_wf with (pa := pa).
     - (* PESingleton p *)
-      destruct (elaborate G p) as [[t' e'] |] eqn : H'; try easy.
+      destruct (elaborate nm G p) as [[t' e'] |] eqn:H'; try easy.
       inversion H.
       apply wf_EBinop.
-      * now apply IHp.
+      * eapply IHp. eassumption.
       * apply wf_EAtom.
     - (* PEUnop po p *)
-      destruct (elaborate G p) as [[t' e'] |] eqn : H'; try easy.
+      destruct (elaborate nm G p) as [[t' e'] |] eqn:H'; try easy.
       apply elaborate_unop_wf with (po := po) (e := e').
-      + now apply IHp.
+      + eapply IHp. eassumption.
       + easy.
     - (* PEBinop po p1 p2 *)
-      destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
-      destruct (elaborate G p2) as [[t2 e2] |] eqn : H2; try easy.
+      destruct (elaborate nm G p1) as [[t1 e1] |] eqn:H1; try easy.
+      destruct (elaborate nm G p2) as [[t2 e2] |] eqn:H2; try easy.
       apply elaborate_binop_wf with (po := po) (e1 := e1) (e2 := e2).
-      + now apply IHp1.
-      + now apply IHp2.
+      + eapply IHp1. eassumption.
+      + eapply IHp2. eassumption.
       + easy.
     - (* PEFlatmap p1 x p2 *)
-      destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
+      destruct (elaborate nm G p1) as [[t1 e1] |] eqn:H1; try easy.
       destruct t1; try easy.
-      destruct (elaborate (map.put G x (t1, false)) p2) as [[t2 e2] |] eqn : H2;
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t1, false)) as G'.
+      destruct (elaborate nm' G' p2) as [[t2 e2] |] eqn:H2;
           try easy.
       destruct t2; try easy.
       inversion H.
       apply wf_EFlatmap.
-      + now apply IHp1.
-      + now apply IHp2.
+      + eapply IHp1. eassumption.
+      + eapply IHp2. subst. eassumption.
+      + admit.
     - (* PEFold p1 p2 x y p3 *)
-      destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
+      destruct (elaborate nm G p1) as [[t1 e1] |] eqn:H1; try easy.
       destruct t1; try easy.
-      destruct (elaborate G p2) as [[t2 e2] |] eqn : H2; try easy.
-      destruct (elaborate (map.put (map.put G x (t1, false)) y (t2, false)) p3) as [[t3 e3] |] eqn : H3; try easy.
-      destruct (enforce_type t2 e3) as [e3' |] eqn : H3'; try easy.
+      destruct (elaborate nm G p2) as [[t2 e2] |] eqn:H2; try easy.
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t1, false)) as G'.
+      remember (tenv_fresh G') as y'.
+      remember (map.put nm' y y') as nm''.
+      remember (map.put G' y' (t2, false)) as G''.
+      destruct (elaborate nm'' G'' p3) as [[t3 e3] |] eqn:H3; try easy.
+      destruct (enforce_type t2 e3) as [e3' |] eqn:H3'; try easy.
       inversion H.
       apply wf_EFold.
-      + now apply IHp1.
-      + now apply IHp2.
-      + apply IHp3. rewrite H3.
+      + eapply IHp1. eassumption.
+      + eapply IHp2. eassumption.
+      + rewrite <- HeqG', <- HeqG''.
+        eapply IHp3. rewrite H3.
         enough (existT expr t3 e3 = existT expr t2 e3').
         { now rewrite <- H0. }
         apply enforce_type_eq.
         exact H3'.
+      + admit.
+      + admit.
     - (* PEIf p1 p2 p3 *)
-      destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
-      destruct (elaborate G p2) as [[t2 e2] |] eqn : H2; try easy.
-      destruct (elaborate G p3) as [[t3 e3] |] eqn : H3; try easy.
-      destruct (enforce_type TBool e1) as [e1' |] eqn : H1'; try easy.
-      destruct (enforce_type t2 e3) as [e3' |] eqn : H3'; try easy.
+      destruct (elaborate nm G p1) as [[t1 e1] |] eqn:H1; try easy.
+      destruct (elaborate nm G p2) as [[t2 e2] |] eqn:H2; try easy.
+      destruct (elaborate nm G p3) as [[t3 e3] |] eqn:H3; try easy.
+      destruct (enforce_type TBool e1) as [e1' |] eqn:H1'; try easy.
+      destruct (enforce_type t2 e3) as [e3' |] eqn:H3'; try easy.
       inversion H.
       apply wf_EIf.
-      + apply IHp1.
+      + eapply IHp1.
         rewrite H1.
         enough (existT expr t1 e1 = existT expr TBool e1').
         { now rewrite <- H0. }
         apply enforce_type_eq.
         exact H1'.
-      + apply IHp2, H2.
-      + apply IHp3.
+      + eapply IHp2, H2.
+      + eapply IHp3.
         rewrite H3.
         enough (existT expr t3 e3 = existT expr t2 e3').
         { now rewrite <- H0. }
         apply enforce_type_eq.
         exact H3'.
     - (* PELet x p1 p2 *)
-      destruct (elaborate G p1) as [[t1 e1] |] eqn : H1; try easy.
-      destruct (elaborate (map.put G x (t1, false)) p2) as [[t2 e2] |] eqn : H2;
+      destruct (elaborate nm G p1) as [[t1 e1] |] eqn:H1; try easy.
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t1, false)) as G'.
+      destruct (elaborate nm' G' p2) as [[t2 e2] |] eqn:H2;
           try easy.
       inversion H.
       apply wf_ELet.
-      + now apply IHp1.
-      + apply IHp2, H2.
+      + eapply IHp1. eassumption.
+      + eapply IHp2. subst. apply H2.
+      + admit.
     - (* PERecord xs *)
       revert G t e H.
       induction xs as [| [s p]]; intros G t e H.
@@ -544,150 +595,157 @@ Section WithMap.
         inversion H. apply wf_EAtom.
       + (* (s, p) :: xs *)
         unfold elaborate_record in H.
-        destruct (elaborate G p) as [[t1 e1] |] eqn : H1; try easy.
-        assert (elaborate_record elaborate G xs =
+        destruct (elaborate nm G p) as [[t1 e1] |] eqn:H1; try easy.
+        assert (elaborate_record elaborate nm G xs =
           (fix elaborate_record
-             (G0 : tenv) (xs0 : list (string * pexpr)) {struct xs0} :
+             (nm0 : namemap) (G0 : tenv) (xs0 : list (string * pexpr)) {struct xs0} :
                result {t0 : type & expr t0} :=
              match xs0 with
              | nil =>
                  Success (existT (fun t0 : type => expr t0) TEmpty (EAtom AEmpty))
              | (s0, p1) :: xs1 =>
-                 ' (existT _ x e0) <- elaborate G0 p1;;
-                 ' (existT _ x0 e2) <- elaborate_record G0 xs1;;
+                 ' (existT _ x e0) <- elaborate nm0 G0 p1;;
+                 ' (existT _ x0 e2) <- elaborate_record nm0 G0 xs1;;
                  Success
                    (existT (fun t0 : type => expr t0) (TPair s0 x x0)
                       (EBinop (OPair s0 x x0) e0 e2))
-             end) G xs
+             end) nm G xs
         ).
         { easy. }
         rewrite <- H0 in H. clear H0.
-        destruct (elaborate_record elaborate G xs) as [[t2 e2] |] eqn : H2; try easy.
+        destruct (elaborate_record elaborate nm G xs) as [[t2 e2] |] eqn:H2; try easy.
         inversion H.
         apply wf_EBinop.
         * apply elaborate_wf in H1. exact H1.
         * apply IHxs. exact H2.
     - (* PEProj p s *)
       unfold elaborate_proj in H.
-      destruct (elaborate G p) as [[t0 e0] |] eqn : H0; try easy.
+      destruct (elaborate nm G p) as [[t0 e0] |] eqn:H0; try easy.
       apply elaborate_proj_wf with (e := e0) (s := s).
-      + now apply IHp.
+      + eapply IHp. eassumption.
       + exact H.
-  Qed.
+  Admitted.
 
-  Fixpoint elaborate_command (G : tenv) (pc : pcommand) : result command :=
+  Fixpoint elaborate_command (nm : namemap) (G : tenv) (pc : pcommand) :
+    result command :=
     match pc with
     | PCSkip =>
         Success CSkip
     | PCSeq pc1 pc2 =>
-        c1 <- elaborate_command G pc1;;
-        c2 <- elaborate_command G pc2;;
+        c1 <- elaborate_command nm G pc1;;
+        c2 <- elaborate_command nm G pc2;;
         Success (CSeq c1 c2)
     | PCLet x p pc =>
-        '(existT _ t e) <- elaborate G p;;
-        match map.get G x with
-        | Some (_, true) =>
-            error:("Variable" x "already defined as mutable")
-        | Some (_, false) | None =>
-            (* If already defined as immutable, shadow that variable *)
-            let G' := map.put G x (t, false) in
-            c <- elaborate_command G' pc;;
-            Success (CLet x e c)
-        end
+        '(existT _ t e) <- elaborate nm G p;;
+        let x' := tenv_fresh G in
+        let nm' := map.put nm x x' in
+        let G' := map.put G x' (t, false) in
+        c <- elaborate_command nm' G' pc;;
+        Success (CLet x' e c)
     | PCLetMut x p pc =>
-        '(existT _ t e) <- elaborate G p;;
-        match map.get G x with
-        | Some (_, true) =>
-            error:("Mutable variable" x "already defined")
-        | Some (_, false) =>
-            error:("Variable" x "already defined as immutable")
-        | None =>
-            let G' := map.put G x (t, true) in
-            c <- elaborate_command G' pc;;
-            Success (CLetMut x e c)
-        end
+        '(existT _ t e) <- elaborate nm G p;;
+        let x' := tenv_fresh G in
+        let nm' := map.put nm x x' in
+        let G' := map.put G x' (t, true) in
+        c <- elaborate_command nm' G' pc;;
+        Success (CLetMut x' e c)
     | PCGets x p =>
-        '(existT _ t e) <- elaborate G p;;
-        match map.get G x with
-        | Some (t', true) =>
-            e' <- enforce_type t' e;;
-            Success (CGets x e')
-        | Some (_, false) =>
-            error:("Variable" x "is not mutable")
-        | None =>
-            error:("Undefined variable" x)
+        '(existT _ t e) <- elaborate nm G p;;
+        match map.get nm x with
+        | Some x' =>
+            match map.get G x' with
+            | Some (t', true) =>
+                e' <- enforce_type t' e;;
+                Success (CGets x' e')
+            | Some (_, false) => error:("Variable" x "is not mutable")
+            | None => error:("Undefined variable" x)
+            end
+        | None => error:("Undefined variable" x)
         end
     | PCIf p pc1 pc2 =>
-        '(existT _ _ e) <- elaborate G p;;
+        '(existT _ _ e) <- elaborate nm G p;;
         e' <- enforce_type TBool e;;
-        c1 <- elaborate_command G pc1;;
-        c2 <- elaborate_command G pc2;;
+        c1 <- elaborate_command nm G pc1;;
+        c2 <- elaborate_command nm G pc2;;
         Success (CIf e' c1 c2)
     | PCForeach x p pc =>
-        '(existT _ t e) <- elaborate G p;;
+        '(existT _ t e) <- elaborate nm G p;;
         match t as t' return expr t' -> _ with
         | TList t => fun e =>
-            let G' := map.put G x (t, false) in
-            c <- elaborate_command G' pc;;
-            Success (CForeach x e c)
+            let x' := tenv_fresh G in
+            let nm' := map.put nm x x' in
+            let G' := map.put G x' (t, false) in
+            c <- elaborate_command nm' G' pc;;
+            Success (CForeach x' e c)
         | _ => fun _ => error:(e "has type" t "but expected" TList)
         end e
     end.
 
-  Lemma elaborate_command_wf (pc : pcommand) : forall G c,
-    elaborate_command G pc = Success c -> wf_command G c.
+  Lemma elaborate_command_wf (pc : pcommand) : forall nm G c,
+    elaborate_command nm G pc = Success c -> wf_command G c.
   Proof.
-    induction pc; intros G c H;
+    induction pc; intros nm G c H;
     unfold elaborate_command in H; fold elaborate_command in H.
     - (* PCSkip *)
       inversion H.
       apply wf_CSkip.
     - (* PCSeq pc1 pc2 *)
-      destruct (elaborate_command G pc1) as [c1 |] eqn:H1; try easy.
-      destruct (elaborate_command G pc2) as [c2 |] eqn:H2; try easy.
+      destruct (elaborate_command nm G pc1) as [c1 |] eqn:H1; try easy.
+      destruct (elaborate_command nm G pc2) as [c2 |] eqn:H2; try easy.
       inversion H.
-      now apply wf_CSeq; [apply IHpc1 | apply IHpc2].
+      now apply wf_CSeq; [eapply IHpc1 | eapply IHpc2]; eassumption.
     - (* PCLet x p pc *)
-      destruct (elaborate G p) as [[t e] |] eqn:He; try easy.
-      destruct (map.get G x) as [[t' [|]] |] eqn : Hmap; try easy;
-      destruct (elaborate_command _ pc) as [c' |] eqn:H'; try easy;
-      inversion H;
-      apply wf_CLet;
-      eapply elaborate_wf, He || now apply IHpc.
+      destruct (elaborate nm G p) as [[t e] |] eqn:He; try easy.
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t, false)) as G'.
+      destruct (elaborate_command _ _ pc) as [c' |] eqn:H'; try easy.
+      inversion H.
+      apply wf_CLet; try eapply elaborate_wf, He.
+      + eapply IHpc. subst. eassumption.
+      + admit.
     - (* PCLetMut x p pc *)
-      destruct (elaborate G p) as [[t e] |] eqn:He; try easy.
-      destruct (map.get G x) as [[t' [|]] |] eqn : Hmap; try easy;
-      destruct (elaborate_command _ pc) as [c' |] eqn:H'; try easy;
-      inversion H;
-      apply wf_CLetMut;
-      eapply elaborate_wf, He || now apply IHpc.
+      destruct (elaborate nm G p) as [[t e] |] eqn:He; try easy.
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t, true)) as G'.
+      destruct (elaborate_command _ _ pc) as [c' |] eqn:H'; try easy.
+      inversion H.
+      apply wf_CLetMut; try eapply elaborate_wf, He.
+      + eapply IHpc. subst. eassumption.
+      + admit.
     - (* PCGets x p *)
-      destruct (elaborate G p) as [[t e] |] eqn:He; try easy.
-      destruct (map.get G x) as [[t' [|]] |] eqn : Hmap; try easy.
-      destruct (enforce_type t' e) as [e' |] eqn : He'; try easy.
+      destruct (elaborate nm G p) as [[t e] |] eqn:He; try easy.
+      destruct (map.get nm x) as [x' |] eqn:Hx'; try easy.
+      destruct (map.get G x') as [[t' [|]] |] eqn:Hmap; try easy.
+      destruct (enforce_type t' e) as [e' |] eqn:He'; try easy.
       inversion H.
       apply wf_CGets.
       + eapply enforce_type_pred, He'.
         eapply elaborate_wf, He.
       + easy.
     - (* PCIf p pc1 pc2 *)
-      destruct (elaborate G p) as [[t e] |] eqn:He; try easy.
-      destruct (enforce_type TBool e) as [e' |] eqn : He'; try easy.
-      destruct (elaborate_command G pc1) as [c1 |] eqn:H1; try easy.
-      destruct (elaborate_command G pc2) as [c2 |] eqn:H2; try easy.
+      destruct (elaborate nm G p) as [[t e] |] eqn:He; try easy.
+      destruct (enforce_type TBool e) as [e' |] eqn:He'; try easy.
+      destruct (elaborate_command nm G pc1) as [c1 |] eqn:H1; try easy.
+      destruct (elaborate_command nm G pc2) as [c2 |] eqn:H2; try easy.
       inversion H.
       apply wf_CIf.
       + eapply enforce_type_pred, He'.
         eapply elaborate_wf, He.
-      + now apply IHpc1.
-      + now apply IHpc2.
+      + eapply IHpc1. eassumption.
+      + eapply IHpc2. eassumption.
     - (* PCForeach x p pc *)
-      destruct (elaborate G p) as [[t e] |] eqn:He; try easy.
+      destruct (elaborate nm G p) as [[t e] |] eqn:He; try easy.
       destruct t; try easy.
-      destruct (elaborate_command _ pc) as [c' |] eqn:H'; try easy.
+      remember (tenv_fresh G) as x'.
+      remember (map.put nm x x') as nm'.
+      remember (map.put G x' (t, false)) as G'.
+      destruct (elaborate_command _ _ pc) as [c' |] eqn:H'; try easy.
       inversion H.
       apply wf_CForeach.
       + eapply elaborate_wf, He.
-      + now apply IHpc.
-  Qed.
+      + eapply IHpc. subst. eassumption.
+      + admit.
+  Admitted.
 End WithMap.

--- a/PyLevelLang/src/PyLevelLang/Examples.v
+++ b/PyLevelLang/src/PyLevelLang/Examples.v
@@ -3,6 +3,7 @@ Require Import PyLevelLang.Elaborate.
 Require Import PyLevelLang.Interpret.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString coqutil.Map.Properties.
 Require Import coqutil.Datatypes.Result.
+Require Import compiler.NameGen compiler.StringNameGen.
 Import ResultMonadNotations.
 
 Section Examples.
@@ -15,8 +16,15 @@ Section Examples.
   Instance locals : map.map string {t & interp_type t} := SortedListString.map _.
   Instance locals_ok : map.ok locals := SortedListString.ok _.
 
+  Instance namemap : map.map string string := SortedListString.map _.
+  Instance namemap_ok : map.ok namemap := SortedListString.ok _.
+  Instance NG : NameGen string N := StringNameGen.
+
   Definition elaborate_interpret (l : locals) (p : pexpr) : result {t & interp_type t} :=
-    e <- elaborate (map.map_values (fun x => (projT1 x, true)) l) p;;
+    let G : tenv := map.map_values (fun x => (projT1 x, true)) l in
+    let vars := map.keys l in
+    let nm : namemap := map.of_list (List.zip pair vars vars) in
+    e <- elaborate nm G p;;
     Success (existT _ _ (interp_expr l (projT2 e))).
 
   Local Open Scope Z_scope.
@@ -27,7 +35,7 @@ Section Examples.
       (PEBinop POCons (PEAtom (PAInt 2))
         (PEBinop POCons (PEAtom (PAInt 3))
           (PESingleton (PEAtom (PAInt 4))))).
-  Goal elaborate map.empty ex1 =
+  Goal elaborate map.empty map.empty ex1 =
     Success (existT _ _
       (EBinop (OCons _) (EAtom (AInt 1))
         (EBinop (OCons _) (EAtom (AInt 2))
@@ -44,7 +52,7 @@ Section Examples.
       PEBinop POCons (PEAtom (PAInt 2)) (
         PEBinop POCons (PEAtom (PAInt 3)) (
           PESingleton (PEAtom (PAInt 4))))).
-  Goal elaborate map.empty ex2 = error:(
+  Goal elaborate map.empty map.empty ex2 = error:(
     (EBinop (OCons TInt) (EAtom (AInt 2))
       (EBinop (OCons TInt) (EAtom (AInt 3))
         (EBinop (OCons TInt) (EAtom (AInt 4))
@@ -68,20 +76,20 @@ Section Examples.
   Definition ex3 : pexpr :=
     PEProj (PELet "x" (PEAtom (PAInt 42))
       (PEBinop POPair (PEVar "x") (PEVar "x"))) "0".
-  Goal elaborate map.empty ex3 =
+  Goal exists x, elaborate map.empty map.empty ex3 =
     Success (existT _ _
-      (EUnop (OFst _ _ _) (ELet "x" (EAtom (AInt 42))
-        (EBinop (OPair "0" _ _) (EVar TInt "x")
-          (EBinop (OPair "1" _ _) (EVar TInt "x")
+      (EUnop (OFst _ _ _) (ELet x (EAtom (AInt 42))
+        (EBinop (OPair "0" _ _) (EVar TInt x)
+          (EBinop (OPair "1" _ _) (EVar TInt x)
             (EAtom AEmpty)))))).
-  reflexivity. Qed.
+  eexists. reflexivity. Qed.
   Goal elaborate_interpret map.empty ex3 = Success (existT _ TInt 42).
   reflexivity. Qed.
 
   Definition ex4 : pexpr :=
     PEProj (PELet "x" (PEAtom (PAInt 42))
       (PEBinop POPair (PEVar "x") (PEVar "y"))) "0".
-  Goal elaborate map.empty ex4 = error:("Undefined variable" "y").
+  Goal elaborate map.empty map.empty ex4 = error:("Undefined variable" "y").
   reflexivity. Qed.
   Goal elaborate_interpret map.empty ex4 = error:("Undefined variable" "y").
   reflexivity. Qed.
@@ -89,7 +97,7 @@ Section Examples.
   Definition ex5 : pexpr :=
     PEBinop POPair (PEAtom (PAInt 42))
       (PEBinop POPair (PEAtom (PABool true)) (PEAtom (PAString "hello"))).
-  Goal elaborate map.empty ex5 =
+  Goal elaborate map.empty map.empty ex5 =
     Success (existT _ _
       (EBinop (OPair "0" _ _) (EAtom (AInt 42))
         (EBinop (OPair "1" _ _)
@@ -115,7 +123,7 @@ Section Examples.
       :: ("string", PEAtom (PAString "abc"))
       :: ("int", PEAtom (PAInt (-2)))
       :: nil).
-  Goal elaborate map.empty ex6 =
+  Goal elaborate map.empty map.empty ex6 =
     Success (existT _ _
       (EBinop (OPair "bool" _ _) (EAtom (ABool false))
         (EBinop (OPair "string" _ _) (EAtom (AString "abc"))
@@ -136,7 +144,7 @@ Section Examples.
       :: ("b", PEAtom (PAInt 50))
       :: nil))
     "b".
-  Goal elaborate map.empty ex7 =
+  Goal elaborate map.empty map.empty ex7 =
     Success (existT _ _
       (EUnop (OFst _ _ _)
         (EUnop (OSnd _ _ _)
@@ -150,13 +158,13 @@ Section Examples.
 
   Definition ex8 : pexpr :=
     PEBinop POEq (PEAtom (PABool true)) (PEAtom (PAInt 5)).
-  Goal elaborate map.empty ex8 =
+  Goal elaborate map.empty map.empty ex8 =
     error:((EAtom (AInt 5)) "has type" TInt "but expected" TBool).
   reflexivity. Qed.
 
   Definition ex9 : pexpr :=
     PEBinop POEq (PEAtom (PABool true)) (PEAtom (PABool false)).
-  Goal elaborate map.empty ex9 =
+  Goal elaborate map.empty map.empty ex9 =
     Success (existT _ _
       (EBinop (OEq TBool eq_refl)
         (EAtom (ABool true)) (EAtom (ABool false)))).

--- a/PyLevelLang/src/PyLevelLang/Queries.v
+++ b/PyLevelLang/src/PyLevelLang/Queries.v
@@ -6,6 +6,7 @@ Require Import PyLevelLang.SamplePrograms.
 Require Import PyLevelLang.Optimize.
 Require Import coqutil.Map.Interface coqutil.Map.SortedListString coqutil.Map.Properties.
 Require Import coqutil.Datatypes.Result.
+Require Import compiler.NameGen compiler.StringNameGen.
 Require Import Coq.Lists.List.
 
 Local Open Scope Z_scope.
@@ -20,6 +21,9 @@ Section Queries_Section.
   Instance tenv_ok : map.ok tenv := SortedListString.ok _.
   Instance locals : map.map string {t & interp_type t} := SortedListString.map _.
   Instance locals_ok : map.ok locals := SortedListString.ok _.
+  Instance namemap : map.map string string := SortedListString.map _.
+  Instance namemap_ok : map.ok namemap := SortedListString.ok _.
+  Instance NG : NameGen string N := StringNameGen.
 
   Fixpoint record (l : list (string * type)) : type :=
     match l with
@@ -123,9 +127,12 @@ Section Queries_Section.
   }>.
   Compute run_program ((("ans", (TList TString, true)) :: nil)) select_test.
 
-  Definition select_test_elaborated' : command := 
-    Eval cbv in match elaborate_command (map.of_list (("ans", (TList TString, true))::nil)) select_test with
-    | Success x => x
+  Definition select_test_elaborated' : command := Eval cbv in
+    let nm := map.of_list (("ans", "ans")::nil) in
+    let G := map.of_list (("ans", (TList TString, true))::nil) in
+    let res := (elaborate_command nm G select_test) in
+    match res with
+    | Success c => c
     | _ => _
     end.
   
@@ -159,9 +166,12 @@ Section Queries_Section.
   }>.
   Compute run_program ((("ans", (TList (t), true))) :: nil) join_test.
 
-  Definition tmp' : command := 
-    Eval cbv in match elaborate_command (map.of_list (("ans", (TList t, true))::nil)) join_test with
-    | Success x => x
+  Definition tmp' : command := Eval cbv in
+    let nm := map.of_list (("ans", "ans")::nil) in
+    let G := map.of_list (("ans", (TList t, true))::nil) in
+    let res := (elaborate_command nm G join_test) in
+    match res with
+    | Success c => c
     | _ => _
     end.
   

--- a/PyLevelLang/src/PyLevelLang/SamplePrograms.v
+++ b/PyLevelLang/src/PyLevelLang/SamplePrograms.v
@@ -889,8 +889,6 @@ Section WithMap.
       interp_command map.empty (isSquare_elaborated (Z.of_nat n))
       = (map.put map.empty "ans" (existT interp_type Bool true)).
    Proof.
-   Admitted.
-   (*
       intros n [x xSq].
 
       simpl.
@@ -991,7 +989,6 @@ Section WithMap.
            rewrite map.remove_empty.
            reflexivity.
    Qed.
-   *)
 End WithMap.
 
 End WithWord.


### PR DESCRIPTION
This still contains some `admit`s relating to proving that names are not reused, which turned out to be harder than expected. I plan on resolving these by creating a new intermediate language that does not allow shadowing (we need to add an intermediate language for notating memory lifetimes anyway), so I figured that I would open a pull request for this separately from those more substantial changes.