### PR TITLE
Fix destruct loop in straightline

### DIFF
--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -122,7 +122,7 @@ Ltac straightline_cleanup :=
   | |- let _ := _ in _ => intros
   | |- dlet.dlet ?v (fun x => ?P) => change (let x := v in P); intros
   | _ => progress (cbn [Semantics.interp_binop] in * )
-  | H: exists _, _ |- _ => destruct H
+  | H: exists _, _ |- _ => assert_succeeds progress destruct H as (_&_); destruct H
   | H: _ /\ _ |- _ => destruct H
   | x := ?y |- ?G => is_var y; subst x
   | H: ?x = ?y |- _ => constr_eq x y; clear H


### PR DESCRIPTION
In some cases, `destruct H` won't be able to clear H from the context. This causes `straightline` to get stuck in a loop, trying to destruct the same hypothesis on each iteration. This change ensures that we only call `destruct H` when we know that this won't happen.