### PR TITLE
Crit-bit Tree: Improve Proofs

### DIFF
--- a/LiveVerif/src/LiveVerifExamples/critbit.v
+++ b/LiveVerif/src/LiveVerifExamples/critbit.v
@@ -1042,16 +1042,6 @@ Derive cbt_update_or_best SuchThat (fun_correct! cbt_update_or_best)
 }                                                                           /**.
 Qed.
 
-Import enable_frame_trick.
-
-Ltac instantiate_frame_evar_with_remaining_obligation ::=
-  lazymatch goal with
-  | |- canceling (cons ?R nil) ?om (enable_frame_trick ?P) =>
-      let P := lazymatch eval pattern R in P with ?f _ => f end in
-      eapply (canceling_done_frame_generic om P);
-      [ solve [clear; unfold sep, ex1; repeat decomposing_intro; eauto 40] | ]
-  end.
-
 #[export] Instance spec_of_cbt_lookup_impl: fnspec :=                           .**/
 uintptr_t cbt_lookup_impl(uintptr_t tp, uintptr_t k, uintptr_t val_out) /**#
   ghost_args := (sk: tree_skeleton) (pr: prefix) (c: word_map)
@@ -1706,7 +1696,7 @@ Derive cbt_insert SuchThat (fun_correct! cbt_insert) As cbt_insert_ok.          
   unfold is_prefix_key, is_prefix, full_prefix in Hprkb. cbn in Hprkb.
   rewrite clip_prefix_bits in Hprkb. steps. steps. steps.
 
-  unfold enable_frame_trick. steps. .**/
+  unfold enable_frame_trick.enable_frame_trick. steps. .**/
       return result;                                                       /**. .**/
     }                                                                      /**.
   replace (\[result] =? 0) with false by steps.

--- a/bedrock2/src/bedrock2/HeapletwiseHyps.v
+++ b/bedrock2/src/bedrock2/HeapletwiseHyps.v
@@ -1105,7 +1105,7 @@ Ltac instantiate_frame_evar_with_remaining_obligation :=
   | |- canceling (cons ?R nil) ?om (enable_frame_trick ?P) =>
       let P := lazymatch eval pattern R in P with ?f _ => f end in
       eapply (canceling_done_frame_generic om P);
-      [ solve [clear; unfold sep; repeat decomposing_intro; eauto 40] | ]
+      [ solve [clear; unfold sep, ex1; repeat decomposing_intro; eauto 40] | ]
   end.
 
 (* both x and y may contain evars, but only evars in y will be instantiated *)

--- a/bedrock2/src/bedrock2/HeapletwiseHyps.v
+++ b/bedrock2/src/bedrock2/HeapletwiseHyps.v
@@ -994,8 +994,6 @@ Ltac merge_du_step :=
       let D := fresh "D" in
       pose proof (merge_two_split_equations E1 E2) as D;
       clear E1 E2
-  | H: map.split ?mm _ _ |- _ =>
-      tryif ident_starts_with m mm then eapply split_du in H else fail
   | E1: ?om1 = @mmap.Def _ _ ?Mem ?m, E2: ?om2 = mmap.Def ?m' |- _ =>
       lazymatch om1 with
       | mmap.du _ _ => idtac

--- a/bedrock2/src/bedrock2/HeapletwiseHyps.v
+++ b/bedrock2/src/bedrock2/HeapletwiseHyps.v
@@ -982,7 +982,7 @@ Ltac destruct_emp_step :=
   | H: with_mem ?m (emp ?P) |- _ => destruct_emp_step0 H m P
   | H: emp ?P ?m            |- _ => destruct_emp_step0 H m P
   end.
-
+Require Import coqutil.Tactics.ident_ops.
 (* usually already done by split_sep_step, but when introducing hyps from the
    frame after a call, separate merging might still be needed: *)
 Ltac merge_du_step :=
@@ -991,7 +991,8 @@ Ltac merge_du_step :=
       let D := fresh "D" in
       pose proof (merge_two_split_equations E1 E2) as D;
       clear E1 E2
-  | H: map.split _ _ _ |- _ => eapply split_du in H
+  | H: map.split ?mm _ _ |- _ =>
+      tryif ident_starts_with m mm then eapply split_du in H else fail
   | E1: ?om1 = @mmap.Def _ _ ?Mem ?m, E2: ?om2 = mmap.Def ?m' |- _ =>
       lazymatch om1 with
       | mmap.du _ _ => idtac

--- a/bedrock2/src/bedrock2/HeapletwiseHyps.v
+++ b/bedrock2/src/bedrock2/HeapletwiseHyps.v
@@ -985,7 +985,7 @@ Ltac destruct_emp_step :=
   | H: with_mem ?m (emp ?P) |- _ => destruct_emp_step0 H m P
   | H: emp ?P ?m            |- _ => destruct_emp_step0 H m P
   end.
-Require Import coqutil.Tactics.ident_ops.
+
 (* usually already done by split_sep_step, but when introducing hyps from the
    frame after a call, separate merging might still be needed: *)
 Ltac merge_du_step :=

--- a/bedrock2/src/bedrock2Examples/indirect_add_heapletwise.v
+++ b/bedrock2/src/bedrock2Examples/indirect_add_heapletwise.v
@@ -191,7 +191,12 @@ H15 : (scalar a0 (word.add va vb) ⋆ (scalar out vout ⋆ R))%sep a2
   Proof. unfold purify. intros. constructor. Qed.
   Hint Resolve purify_scalar: purify.
 
-  Ltac straightline_stackalloc ::= fail.
+  Ltac straightline_stackalloc ::=
+    lazymatch goal with
+    | Ha : anybytes _ _ ?mStack, Hs : map.split ?mCombined ?m ?mStack |- _ =>
+        eapply split_du in Hs
+    end.
+
   Ltac straightline_stackdealloc ::= fail.
 
   Ltac straightline_call ::=


### PR DESCRIPTION
* don't reference hyps using auto-generated names
* increase automation using `step_hook`
* remove use of magic wands