### PR TITLE
sepapps safe to cancel

### DIFF
--- a/LiveVerif/src/LiveVerif/LiveProgramLogic.v
+++ b/LiveVerif/src/LiveVerif/LiveProgramLogic.v
@@ -1079,6 +1079,16 @@ Ltac predicates_safe_to_cancel hypPred conclPred :=
                                                        by (zify_goal; xlia zchecker));
                                     tryif is_evar vs2 then unify vs1 vs2 else idtac
                                 end
+      | sepapps nil => lazymatch hypPred with
+                       | sepapps nil => idtac
+                       end
+      | sepapps (cons (mk_sized_predicate ?P2 ?Psize2) ?rest2) =>
+            lazymatch hypPred with
+            | sepapps (cons (mk_sized_predicate ?P1 ?Psize1) ?rest1) =>
+               unify Psize1 Psize2;
+               predicates_safe_to_cancel P1 P2;
+               predicates_safe_to_cancel (sepapps rest1) (sepapps rest2)
+            end
       end ].
 
 (* can instantiate evars in goalClause *)

--- a/LiveVerif/src/LiveVerif/LiveProgramLogic.v
+++ b/LiveVerif/src/LiveVerif/LiveProgramLogic.v
@@ -1085,8 +1085,8 @@ Ltac predicates_safe_to_cancel hypPred conclPred :=
       | sepapps (cons (mk_sized_predicate ?P2 ?Psize2) ?rest2) =>
             lazymatch hypPred with
             | sepapps (cons (mk_sized_predicate ?P1 ?Psize1) ?rest1) =>
-               unify Psize1 Psize2;
-               predicates_safe_to_cancel P1 P2;
+               constr_eq Psize1 Psize2;
+               tryif constr_eq P1 P2 then idtac else predicates_safe_to_cancel P1 P2;
                predicates_safe_to_cancel (sepapps rest1) (sepapps rest2)
             end
       end ].

--- a/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
+++ b/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
@@ -6,10 +6,10 @@ Load LiveVerif.
 #[export] Instance spec_of_pass_three: fnspec :=                                .**/
 
 void pass_three(uintptr_t src) /**#
-  ghost_args := (R: mem -> Prop) (w1 w2 w3: word);
-  requires t m := <{ * <{ + uintptr w1 + uintptr w2 + uintptr w3 }> src
+  ghost_args := (R: mem -> Prop) (w2 w3: word);
+  requires t m := <{ * <{ + uintptr /[42] + uintptr w2 + uintptr w3 }> src
                      * R }> m;
-  ensures t' m' := t' = t /\ <{ * <{ + uintptr w1 + uintptr w2 + uintptr w3 }> src
+  ensures t' m' := t' = t /\ <{ * <{ + uintptr /[42] + uintptr w2 + uintptr w3 }> src
                                 * R }> m'    #**/                          /**.
 Derive pass_three SuchThat (fun_correct! pass_three) As pass_three_ok.                .**/
 {                                                                          /**. .**/
@@ -20,9 +20,9 @@ Qed.
 
 void main( ) /**#
   ghost_args := (R: mem -> Prop);
-  requires t m := <{ * <{ + uintptr /[3] + uintptr /[7] + uintptr /[4] }> /[40000]
+  requires t m := <{ * <{ + uintptr /[42] + uintptr /[7] + uintptr /[4] }> /[40000]
                      * R }> m;
-  ensures t' m' := t' = t /\ <{ * <{ + uintptr /[3] + uintptr /[7] + uintptr /[4] }> /[40000]
+  ensures t' m' := t' = t /\ <{ * <{ + uintptr /[42] + uintptr /[7] + uintptr /[4] }> /[40000]
                                 * R }> m' #**/                             /**.
 Derive main SuchThat (fun_correct! main) As main_ok.                            .**/
 {                                                                          /**. .**/

--- a/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
+++ b/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
@@ -1,0 +1,38 @@
+(* -*- eval: (load-file "../LiveVerif/live_verif_setup.el"); -*- *)
+Require Import LiveVerif.LiveVerifLib.
+
+Load LiveVerif.
+
+#[export] Instance spec_of_pass_three: fnspec :=                                .**/
+
+void pass_three(uintptr_t src) /**#
+  ghost_args := (R: mem -> Prop) (w1 w2 w3: word);
+  requires t m := <{ * <{ + uintptr w1 + uintptr w2 + uintptr w3 }> src
+                     * R }> m;
+  ensures t' m' := t' = t /\ <{ * <{ + uintptr w1 + uintptr w2 + uintptr w3 }> src
+                                * R }> m'    #**/                          /**.
+Derive pass_three SuchThat (fun_correct! pass_three) As pass_three_ok.                .**/
+{                                                                          /**. .**/
+}                                                                          /**.
+Qed.
+
+#[export] Instance spec_of_main: fnspec :=                                      .**/
+
+void main( ) /**#
+  ghost_args := (R: mem -> Prop);
+  requires t m := <{ * <{ + uintptr /[3] + uintptr /[7] + uintptr /[4] }> /[40000]
+                     * R }> m;
+  ensures t' m' := t' = t /\ <{ * <{ + uintptr /[3] + uintptr /[7] + uintptr /[4] }> /[40000]
+                                * R }> m' #**/                             /**.
+Derive main SuchThat (fun_correct! main) As main_ok.                            .**/
+{                                                                          /**. .**/
+  pass_three(40000);                                                       /**.
+  (* checking that the sepapps in the precondition of pass_three is
+     canceled by the caller's sepapps all at once *)
+  Fail match goal with
+  | H: context [ hole ] |- _ => idtac
+  end. .**/
+}                                                                          /**.
+Qed.
+
+End LiveVerif. Comments .**/ //.


### PR DESCRIPTION
In LiveVerif: Making `predicates_safe_to_cancel` succeed if both the hypothesis and the conclusion is a `sepapps` and all the corresponding constituent predicates are safe to cancel (checked recursively). Adding a test for this (which would previously fail).