### PR TITLE
Try assumption when checking if purified hyp already derivable

### DIFF
--- a/LiveVerif/src/LiveVerifExamples/critbit.v
+++ b/LiveVerif/src/LiveVerifExamples/critbit.v
@@ -955,7 +955,8 @@ Qed.
 
 Ltac apply_key_prefix_hyp :=
   match goal with
-  | Hq: context[ map.get ?c _ <> None -> _ ], Hc: map.get ?c _ <> None |- _ =>
+  | Hq: context[ map.get ?c _ <> None -> is_prefix_key _ _ ],
+    Hc: map.get ?c _ <> None |- _ =>
     apply Hq in Hc
   end.
 
@@ -1290,7 +1291,10 @@ Derive cbt_insert_at SuchThat (fun_correct! cbt_insert_at) As cbt_insert_at_ok. 
   {                                                                        /*?.
   subst v0.
   repeat heapletwise_step.
-  apply cbt_expose_fields in H13. steps.
+  match goal with
+  | H: _ |= cbt' _ _ _ _ |- _ => apply cbt_expose_fields in H
+  end.
+  steps.
   destruct sk; [ exfalso | ]. steps.
   .**/
     if (((k >> load(p)) & 1) == 1) /* split */ {                            /**. .**/
@@ -1494,9 +1498,9 @@ Derive cbt_insert_at SuchThat (fun_correct! cbt_insert_at) As cbt_insert_at_ok. 
   apply append_1_prefix in Hprk. steps. steps.
   assert (prefix_bits \[cb] k = prefix_bits \[cb] k0).
   assert (is_prefix_key pr k). apply_key_prefix_hyp. steps.
-  assert (prefix_bits (length pr) k = prefix_bits (length pr) k').
-  apply same_prefix_bits_equality; steps. congruence. steps.
-  edestruct is_prefix_extend_0_or_1; [ | | |  eassumption | ]; cbn; steps.
+  assert (prefix_bits (length pr) k = prefix_bits (length pr) k')
+    by (apply same_prefix_bits_equality; steps). congruence. steps.
+  edestruct is_prefix_extend_0_or_1; [ | | | eassumption | ]; cbn; steps.
   assert (prefix_bits (length pr) (bits pr) = prefix_bits (length pr) k').
   match goal with
   | H: is_prefix_key pr k' |- _ => unfold is_prefix_key, is_prefix, full_prefix in H

--- a/bedrock2/src/bedrock2/PurifyHeapletwise.v
+++ b/bedrock2/src/bedrock2/PurifyHeapletwise.v
@@ -9,8 +9,11 @@ Require Import coqutil.Tactics.ident_ops.
 Require Import bedrock2.bottom_up_simpl.
 Require Import bedrock2.unzify.
 
+Ltac split_and_solve_trivial :=
+  repeat match goal with | |- _ /\ _ => split end; try assumption.
+
 Ltac fail_if_too_trivial t :=
-  assert_fails (idtac; assert t by xlia zchecker).
+  assert_fails (idtac; assert t by (split_and_solve_trivial; xlia zchecker)).
 
 Ltac puri_simpli_zify_hyp fastMode h t :=
   let pure := purified_hyp h t in
@@ -48,7 +51,8 @@ Inductive derivability_test_marker: Prop := mk_derivability_test_marker.
 
 Ltac clear_pure_hyp_if_derivable h tp :=
   tryif ident_starts_with __pure_ h then
-    try (clear h; assert_succeeds (idtac; assert tp by (zify_goal; xlia zchecker)))
+    try (clear h; assert_succeeds (idtac; assert tp by
+      (split_and_solve_trivial; zify_goal; xlia zchecker)))
   else idtac.
 
 Ltac clear_upto_marker marker :=

--- a/bedrock2/src/bedrock2/PurifyHeapletwise.v
+++ b/bedrock2/src/bedrock2/PurifyHeapletwise.v
@@ -9,11 +9,14 @@ Require Import coqutil.Tactics.ident_ops.
 Require Import bedrock2.bottom_up_simpl.
 Require Import bedrock2.unzify.
 
-Ltac split_and_solve_trivial :=
-  repeat match goal with | |- _ /\ _ => split end; try assumption.
+Ltac split_and_try_exact :=
+  repeat match goal with
+  | H: ?P1 |- ?P2 => constr_eq_nounivs P1 P2; exact H
+  | |- _ /\ _ => split
+  end.
 
 Ltac fail_if_too_trivial t :=
-  assert_fails (idtac; assert t by (split_and_solve_trivial; xlia zchecker)).
+  assert_fails (idtac; assert t by (split_and_try_exact; xlia zchecker)).
 
 Ltac puri_simpli_zify_hyp fastMode h t :=
   let pure := purified_hyp h t in
@@ -52,7 +55,7 @@ Inductive derivability_test_marker: Prop := mk_derivability_test_marker.
 Ltac clear_pure_hyp_if_derivable h tp :=
   tryif ident_starts_with __pure_ h then
     try (clear h; assert_succeeds (idtac; assert tp by
-      (split_and_solve_trivial; zify_goal; xlia zchecker)))
+      (split_and_try_exact; zify_goal; xlia zchecker)))
   else idtac.
 
 Ltac clear_upto_marker marker :=


### PR DESCRIPTION
Instead of just running `xlia`, checking if the purified version of a hyp can already be derived now also splits all `and`s and tries the `assumption` tactic.