### PR TITLE
Canceling pairs of uintptr's or uint's

### DIFF
--- a/LiveVerif/src/LiveVerif/LiveProgramLogic.v
+++ b/LiveVerif/src/LiveVerif/LiveProgramLogic.v
@@ -721,8 +721,8 @@ Ltac default_careful_reflexivity_step :=
       lazymatch goal with
       | |- _ (sepapps _ _) (sepapps _ _) => idtac
       end
-  | |- uintptr ?l = uintptr ?r => eapply f_equal
-  | |- uint ?nbits ?l = uint ?nbits ?r => eapply f_equal
+  | |- eq (uintptr _) (uintptr _) => eapply f_equal
+  | |- eq (uint ?nbits _) (uint ?nbits _) => eapply f_equal
   | |- _ ?l ?r => subst l
   | |- _ ?l ?r => subst r
   | |- _ => turn_relation_into_eq; syntactic_f_equal_with_ZnWords

--- a/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
+++ b/LiveVerif/src/LiveVerifExamples/Tests/test_sepapps_safe_to_cancel.v
@@ -7,7 +7,9 @@ Load LiveVerif.
 
 void pass_three(uintptr_t src) /**#
   ghost_args := (R: mem -> Prop) (w2 w3: word);
-  requires t m := <{ * <{ + uintptr /[42] + uintptr w2 + uintptr w3 }> src
+  (* using (w2 ^+ /[0]) to test the case when the value in a uintptr is not just
+     an evar *)
+  requires t m := <{ * <{ + uintptr /[42] + uintptr (w2 ^+ /[0]) + uintptr w3 }> src
                      * R }> m;
   ensures t' m' := t' = t /\ <{ * <{ + uintptr /[42] + uintptr w2 + uintptr w3 }> src
                                 * R }> m'    #**/                          /**.

--- a/LiveVerif/src/LiveVerifExamples/critbit.v
+++ b/LiveVerif/src/LiveVerifExamples/critbit.v
@@ -1426,10 +1426,9 @@ Derive cbt_insert_at SuchThat (fun_correct! cbt_insert_at) As cbt_insert_at_ok. 
   apply same_prefix_bits_equality. 2: assumption.
   enough (is_prefix_key pr k'). steps.
   apply_key_prefix_hyp. step.
-  step. step. step. step. step. step. step. step. step. step. step. step. step.
-  step. step. step. step. step. step. step. step. step. step. step. step. step.
-  step. step. step. step. step. step. step. instantiate (2:=c). instantiate (3:=pr).
-  repeat clear_array_0.
+  step. step. step. step. step. step. step. step. step.
+  instantiate (2:=c). instantiate (3:=pr). step. step. step. step. steps.
+  step. repeat clear_array_0.
   simpl cbt' in *. instantiate (2:=full_prefix k). instantiate (1:=map.singleton k v).
   destruct sk; simpl cbt'; steps; cbn; steps. subst. steps.
   unfold is_canonic. unfold canonic_bits. cbn. rewrite clip_prefix_bits; steps.
@@ -1558,14 +1557,11 @@ Derive cbt_insert_at SuchThat (fun_correct! cbt_insert_at) As cbt_insert_at_ok. 
   apply same_prefix_bits_equality. 2: assumption.
   enough (is_prefix_key pr k'). steps.
   apply_key_prefix_hyp. step. simpl cbt' in *. simpl length.
-  step. step. step. step. step. step. step. step. step. step. step. step. step.
+  step. step. step. step. step. step. step. step. step. step. step. step. steps.
   step. step. step. step. step. step. step. step. step. step. step.
   repeat match goal with
   | H: _ /\ _ |- _ => destruct H; idtac H
-  end. subst. step. step.
-  step. step. step. step. step. step. step.
-  step. step. step. step. step. step.
-  step. unfold canceling. unfold seps. step. step.
+  end. subst. unfold canceling. unfold seps. step. step.
   2: apply I.
   step. step. apply sep_comm.
   step. step. step. step.


### PR DESCRIPTION
In LiveVerif, with this PR

* `predicates_safe_to_cancel` now considers two `uintptr` predicates always safe to cancel; similarly for two `uint` predicates if they have the same bit width. This is in contrast to the previous behavior where the value in the conclusion predicate had to be a simple evar.

* `default_careful_reflexivity_step` now simplifies the equality two `uintptr` predicates (without addresses) to the equality of their values; similarly for two `uint` predicates if they have the same bit width.