### PR TITLE
[CI] Add coq-check-all job for ease of branch protection

### DIFF
--- a/.github/workflows/coq.yml
+++ b/.github/workflows/coq.yml
@@ -67,3 +67,13 @@ jobs:
         submodules: recursive
     - name: make
       run: TIMED=1 make
+
+  coq-check-all:
+    runs-on: ubuntu-latest
+    needs: build
+    if: always()
+    steps:
+    - run: echo 'build passed'
+      if: ${{ needs.build.result == 'success' }}
+    - run: echo 'build failed' && false
+      if: ${{ needs.build.result != 'success' }}


### PR DESCRIPTION
This allows branch protection (for automerge) that doesn't need to evolve as tested Coq versions change (just make the only required check be coq-check-all)

(The status checks at https://github.com/mit-plv/bedrock2/pull/375 suggest that the branch protection currently lists explicit jobs)
![image](https://github.com/mit-plv/bedrock2/assets/396076/5a95f648-fca8-4b56-9b56-d2e74e2e9251)
