### PR TITLE
Schedule submodule-update CI 15min earlier

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-      time: "06:00"
+      time: "05:45"
     labels:
       - "submodules"


### PR DESCRIPTION
https://github.com/mit-plv/bedrock2/pull/426 was created 42 minutes after the scheduled time, missing the daily update window for rupicola, and delaying https://github.com/coq/coq/pull/19310#issuecomment-2230078768 by 24 hours. In lieu of getting a cron that can actually keep time, I'll fudge this one just a bit for now.