### PR TITLE
Update proof for cancel that removes equal terms

### DIFF
--- a/bedrock2/src/bedrock2/SepCalls.v
+++ b/bedrock2/src/bedrock2/SepCalls.v
@@ -106,7 +106,7 @@ Section SepLog.
     rewrite H0.
     rewrite 2seps_app in H1. rewrite seps_app.
     rewrite seps_cons.
-    cancel. cancel_seps_at_indices_by_implication 0%nat 0%nat. 1: exact impl1_refl.
+    cancel.
     cbn [seps].
     etransitivity. 2: eassumption.
     ecancel.


### PR DESCRIPTION
This proof will need to be update to match https://github.com/mit-plv/coqutil/pull/145