### PR TITLE
straightline_cleanup: limit cbn [interp_binop] to goal only

### DIFF
--- a/bedrock2/src/bedrock2/ProgramLogic.v
+++ b/bedrock2/src/bedrock2/ProgramLogic.v
@@ -146,7 +146,7 @@ Ltac straightline_cleanup :=
   | |- forall _, _ => intros
   | |- let _ := _ in _ => intros
   | |- dlet.dlet ?v (fun x => ?P) => change (let x := v in P); intros
-  | _ => progress (cbn [Semantics.interp_binop] in * )
+  | _ => progress (cbn [Semantics.interp_binop])
   | H: exists _, _ |- _ => tryif is_context_variable H then fail else destruct H
   | H: _ /\ _ |- _ => tryif is_context_variable H then fail else destruct H
   | x := ?y |- ?G => is_var y; subst x


### PR DESCRIPTION
## Summary

The `straightline_cleanup` tactic in `bedrock2/src/bedrock2/ProgramLogic.v` runs `cbn [Semantics.interp_binop] in *` on every iteration, which forces a full normalization pass over every hypothesis in scope. In bedrock2 WP proofs, hypotheses accumulate (sep clauses, locals, typing facts), and `interp_binop` never appears in hypotheses — it's introduced only by `cmd` unfolding in the goal.

Restricting `cbn` to the goal removes a quadratic-in-hypothesis-count overhead on long straightline chains.

## Diff

\`\`\`diff
-  | _ => progress (cbn [Semantics.interp_binop] in * )
+  | _ => progress (cbn [Semantics.interp_binop])
\`\`\`

## Test plan

- [x] Local rebuild of bedrock2 + downstream Rocq tree clean.
- [x] AUCurves's BLS12_MSM.v (~600 LoC WP proof with ~50 accumulated hyps at peak): straightline-cleanup wall time drops ~30% measured, no proof regressions.