### PR TITLE
Change full_add and full_mul `spec_of` instances to `#[export]`.

### DIFF
--- a/bedrock2/src/bedrock2Examples/full_add.v
+++ b/bedrock2/src/bedrock2Examples/full_add.v
@@ -17,7 +17,7 @@ From bedrock2 Require Import WeakestPrecondition ProgramLogic BasicC64Semantics.
 Import coqutil.Word.Interface.
 Require Import bedrock2.ZnWords.
 
-Local Instance spec_of_full_add : spec_of "br_full_add" :=
+#[export] Instance spec_of_full_add : spec_of "br_full_add" :=
   fnspec! "br_full_add" x y carry ~> sum carry_out,
     { (* The required upper bound on `carry` isn't necessary for the
          current `br_full_add` to support the `ensures` clause, but

--- a/bedrock2/src/bedrock2Examples/full_mul.v
+++ b/bedrock2/src/bedrock2Examples/full_mul.v
@@ -27,7 +27,7 @@ Definition br_full_mul :=
       low = (second_halfword_w_oflow << n) + (ll & M)
     }.
 
-Local Instance spec_of_full_mul : spec_of "br_full_mul" :=
+#[export] Instance spec_of_full_mul : spec_of "br_full_mul" :=
   fnspec! "br_full_mul" a b ~> low high,
     { requires t m := True;
       ensures T M :=


### PR DESCRIPTION
This PR changes the instances of `spec_of` for `full_add` and `full_mul` to `#[export]` from `Local`. `full_add` and `full_mul` are functions which are commonly used, thus making it preferable to have these instances marked as `#[export]`. Moreover, this adds consistency, since `full_sub` has already been exported in #521. 